### PR TITLE
Bugfix/cloudwatch logs 401

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,29 +24,55 @@ repositories {
 }
 
 dependencies {
+    // --- Spring Boot ---
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
-    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0")
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
+
+    // OpenAPI (Swagger UI)
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
+
+    // JWT
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
-    compileOnly 'org.projectlombok:lombok'
-    developmentOnly 'org.springframework.boot:spring-boot-devtools'
-    runtimeOnly 'com.mysql:mysql-connector-j'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+    // Lombok
+    compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
+
+    // DevTools
+    developmentOnly 'org.springframework.boot:spring-boot-devtools'
+
+    // DB Driver
+    runtimeOnly 'com.mysql:mysql-connector-j'  // 9.x 사용 중 (OK)
+
+    // --- Test ---
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-    implementation 'org.springframework.boot:spring-boot-starter-cache'
-    implementation platform("io.awspring.cloud:spring-cloud-aws-dependencies:3.0.2")
-    implementation 'io.awspring.cloud:spring-cloud-aws-starter-sqs'
-    //implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
-    //implementation 'io.awspring.cloud:spring-cloud-aws-messaging:3.1.0'
 
+    // --- AWS Spring Cloud (SQS) ---
+    // spring-cloud-aws BOM (starter 버전 정합성만 관리; SDK 버전은 아래에서 별도 BOM으로 고정)
+    implementation platform('io.awspring.cloud:spring-cloud-aws-dependencies:3.0.2')
 
+    // starter가 끌고오는 software.amazon.awssdk(구버전)를 제외하고, 아래에서 우리가 지정한 BOM 버전을 사용
+    implementation('io.awspring.cloud:spring-cloud-aws-starter-sqs') {
+        exclude group: 'software.amazon.awssdk'
+    }
+
+    // --- AWS SDK v2 : BOM으로 2.25.62 고정 (충돌 방지) ---
+    implementation platform('software.amazon.awssdk:bom:2.25.62')
+
+    // 필요한 서비스 클라이언트 모듈들 (버전 표기 금지: BOM이 관리)
+    implementation 'software.amazon.awssdk:sqs'
+    implementation 'software.amazon.awssdk:cloudwatch'
+    implementation 'software.amazon.awssdk:cloudwatchlogs'
+
+    // 필요 시 추가 예: implementation 'software.amazon.awssdk:sts' 등
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/moyeorak/config/AwsClientsConfig.java
+++ b/src/main/java/com/example/moyeorak/config/AwsClientsConfig.java
@@ -3,11 +3,13 @@ package com.example.moyeorak.config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import lombok.extern.slf4j.Slf4j;
 
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.cloudwatch.CloudWatchClient;
 import software.amazon.awssdk.services.cloudwatchlogs.CloudWatchLogsClient;
 
+@Slf4j
 @Configuration
 public class AwsClientsConfig {
 
@@ -20,7 +22,7 @@ public class AwsClientsConfig {
         CloudWatchClient client = CloudWatchClient.builder()
                 .region(Region.of(region))
                 .build(); // 자격증명: 기본 프로바이더 체인(IAM Role/환경변수/SharedCredentials)
-        System.out.println("[CloudWatch] region=" + region);
+        log.info("[CloudWatch] region={}", region);
         return client;
     }
 
@@ -29,7 +31,7 @@ public class AwsClientsConfig {
         CloudWatchLogsClient client = CloudWatchLogsClient.builder()
                 .region(Region.of(region))
                 .build();
-        System.out.println("[CloudWatchLogs] region=" + region);
+        log.info("[CloudWatchLogs] region={}", region);
         return client;
     }
 }

--- a/src/main/java/com/example/moyeorak/config/AwsClientsConfig.java
+++ b/src/main/java/com/example/moyeorak/config/AwsClientsConfig.java
@@ -11,21 +11,25 @@ import software.amazon.awssdk.services.cloudwatchlogs.CloudWatchLogsClient;
 @Configuration
 public class AwsClientsConfig {
 
-    // application.yml에 aws.region이 없을 때 기본값으로 ap-northeast-2 사용
+    // application.properties 에 aws.region이 없을 때 기본값으로 ap-northeast-2 사용
     @Value("${aws.region:ap-northeast-2}")
     private String region;
 
     @Bean
     public CloudWatchClient cloudWatchClient() {
-        return CloudWatchClient.builder()
+        CloudWatchClient client = CloudWatchClient.builder()
                 .region(Region.of(region))
                 .build(); // 자격증명: 기본 프로바이더 체인(IAM Role/환경변수/SharedCredentials)
+        System.out.println("[CloudWatch] region=" + region);
+        return client;
     }
 
     @Bean
     public CloudWatchLogsClient cloudWatchLogsClient() {
-        return CloudWatchLogsClient.builder()
+        CloudWatchLogsClient client = CloudWatchLogsClient.builder()
                 .region(Region.of(region))
                 .build();
+        System.out.println("[CloudWatchLogs] region=" + region);
+        return client;
     }
 }

--- a/src/main/java/com/example/moyeorak/config/AwsClientsConfig.java
+++ b/src/main/java/com/example/moyeorak/config/AwsClientsConfig.java
@@ -1,0 +1,31 @@
+package com.example.moyeorak.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.cloudwatch.CloudWatchClient;
+import software.amazon.awssdk.services.cloudwatchlogs.CloudWatchLogsClient;
+
+@Configuration
+public class AwsClientsConfig {
+
+    // application.yml에 aws.region이 없을 때 기본값으로 ap-northeast-2 사용
+    @Value("${aws.region:ap-northeast-2}")
+    private String region;
+
+    @Bean
+    public CloudWatchClient cloudWatchClient() {
+        return CloudWatchClient.builder()
+                .region(Region.of(region))
+                .build(); // 자격증명: 기본 프로바이더 체인(IAM Role/환경변수/SharedCredentials)
+    }
+
+    @Bean
+    public CloudWatchLogsClient cloudWatchLogsClient() {
+        return CloudWatchLogsClient.builder()
+                .region(Region.of(region))
+                .build();
+    }
+}

--- a/src/main/java/com/example/moyeorak/config/SecurityConfig.java
+++ b/src/main/java/com/example/moyeorak/config/SecurityConfig.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
@@ -31,6 +32,7 @@ public class SecurityConfig {
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)
+                .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
 

--- a/src/main/java/com/example/moyeorak/config/SecurityConfig.java
+++ b/src/main/java/com/example/moyeorak/config/SecurityConfig.java
@@ -8,6 +8,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
@@ -26,10 +27,14 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
-                .csrf(csrf -> csrf.disable())
+                .csrf(AbstractHttpConfigurer::disable)
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+
+                        // --- 공개 엔드포인트 ---
                         .requestMatchers(
                                 "/actuator/health", "/actuator/info", "/health",
                                 "/api/users/signup", "/api/users/login",
@@ -48,15 +53,26 @@ public class SecurityConfig {
                                 "/swagger-ui/**", "/swagger-ui.html",
                                 "/v3/api-docs/**", "/v3/api-docs.yaml"
                         ).permitAll()
+
+                        // --- CloudWatch 프록시: 기본은 인증 필요 ---
+                        .requestMatchers("/api/cloudwatch/**").authenticated()
+                        // 만약 공개로 열고 싶으면 위 줄을 주석 처리하고 아래 줄 사용
+                        // .requestMatchers("/api/cloudwatch/**").permitAll()
+
+                        // --- 관리자 ---
                         .requestMatchers("/api/admin/**").hasAuthority("ROLE_ADMIN")
+
+                        // 그 외 전부 인증 필요
                         .anyRequest().authenticated()
                 )
                 .exceptionHandling(ex -> ex
                         .authenticationEntryPoint((request, response, authException) -> {
+                            // 인증 안 됨 → 401
                             response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "인증이 필요합니다.");
                         })
                         .accessDeniedHandler((request, response, accessDeniedException) -> {
-                            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "접근 권한이 없습니다.");
+                            // 권한 없음 → 403 (기존 401 잘못 반환하던 것 수정)
+                            response.sendError(HttpServletResponse.SC_FORBIDDEN, "접근 권한이 없습니다.");
                         })
                 )
                 .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);
@@ -67,6 +83,7 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
+        // 정확한 오리진만 허용 (와일드카드 X)
         config.setAllowedOrigins(List.of(
                 "http://localhost:3000",
                 "http://localhost:8080",
@@ -78,7 +95,11 @@ public class SecurityConfig {
                 "https://api.moyeorak.cloud"
         ));
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
-        config.setAllowedHeaders(List.of("Authorization", "Content-Type", "X-Requested-With", "Accept", "Origin"));
+        config.setAllowedHeaders(List.of(
+                "Authorization", "Content-Type", "X-Requested-With", "Accept", "Origin"
+        ));
+        // 프론트에서 파일/이미지/다운로드 처리 시 필요할 수 있는 헤더 노출
+        config.setExposedHeaders(List.of("Content-Disposition", "Location"));
         config.setAllowCredentials(true);
         config.setMaxAge(3600L); // 1시간 preflight 캐시
 

--- a/src/main/java/com/example/moyeorak/controller/CloudWatchController.java
+++ b/src/main/java/com/example/moyeorak/controller/CloudWatchController.java
@@ -1,0 +1,33 @@
+package com.example.moyeorak.controller;
+
+import com.example.moyeorak.dto.LogsQueryRequest;
+import com.example.moyeorak.dto.MetricQueryRequest;
+import com.example.moyeorak.dto.MetricQueryResponse;
+import com.example.moyeorak.service.CloudWatchService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/cloudwatch")
+@RequiredArgsConstructor
+public class CloudWatchController {
+
+    private final CloudWatchService service;
+
+    @PostMapping("/metrics")
+    public MetricQueryResponse getMetrics(@RequestBody @Valid MetricQueryRequest req) {
+        return service.getMetricData(req);
+    }
+
+    @PostMapping("/logs/query")
+    public List<Map<String, Object>> queryLogs(@RequestBody @Valid LogsQueryRequest req) throws InterruptedException {
+        return service.runLogsInsights(req);
+    }
+}

--- a/src/main/java/com/example/moyeorak/controller/CloudWatchController.java
+++ b/src/main/java/com/example/moyeorak/controller/CloudWatchController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 
 @RestController
 @RequestMapping("/api/cloudwatch")
@@ -27,7 +28,11 @@ public class CloudWatchController {
     }
 
     @PostMapping("/logs/query")
-    public List<Map<String, Object>> queryLogs(@RequestBody @Valid LogsQueryRequest req) throws InterruptedException {
-        return service.runLogsInsights(req);
+    public CompletableFuture<List<Map<String, Object>>> queryLogs(@RequestBody @Valid LogsQueryRequest req) {
+        return service.runLogsInsightsAsync(req)
+                .exceptionally(ex -> {
+                    // 예외 발생 시 처리 (ex.getMessage() 로 클라이언트에 알려주거나 로깅 가능)
+                    throw new RuntimeException("Failed to query logs: " + ex.getMessage(), ex);
+                });
     }
 }

--- a/src/main/java/com/example/moyeorak/dto/LogsQueryRequest.java
+++ b/src/main/java/com/example/moyeorak/dto/LogsQueryRequest.java
@@ -1,0 +1,14 @@
+package com.example.moyeorak.dto;
+
+import lombok.Data;
+
+import java.time.Instant;
+import java.util.List;
+
+@Data
+public class LogsQueryRequest {
+    private List<String> logGroupNames; // 조회할 로그 그룹들
+    private String queryString;         // 예: fields @timestamp, @message | sort @timestamp desc | limit 50
+    private Instant startTime;
+    private Instant endTime;
+}

--- a/src/main/java/com/example/moyeorak/dto/MetricQueryRequest.java
+++ b/src/main/java/com/example/moyeorak/dto/MetricQueryRequest.java
@@ -1,0 +1,17 @@
+package com.example.moyeorak.dto;
+
+import lombok.Data;
+
+import java.time.Instant;
+import java.util.Map;
+
+@Data
+public class MetricQueryRequest {
+    private String namespace;          // 예: AWS/EC2
+    private String metricName;         // 예: CPUUtilization
+    private Map<String, String> dimensions; // { "InstanceId": "i-0123..." }
+    private String stat;               // Average | Sum | Maximum ...
+    private Integer period;            // 초 단위 (예: 60)
+    private Instant startTime;         // ISO8601
+    private Instant endTime;           // ISO8601
+}

--- a/src/main/java/com/example/moyeorak/dto/MetricQueryResponse.java
+++ b/src/main/java/com/example/moyeorak/dto/MetricQueryResponse.java
@@ -1,0 +1,15 @@
+package com.example.moyeorak.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.time.Instant;
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+public class MetricQueryResponse {
+    private String id;
+    private List<Double> values;
+    private List<Instant> timestamps;
+}

--- a/src/main/java/com/example/moyeorak/service/CloudWatchService.java
+++ b/src/main/java/com/example/moyeorak/service/CloudWatchService.java
@@ -7,6 +7,9 @@ import java.time.Instant;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.Executor;
 
 import software.amazon.awssdk.services.cloudwatch.CloudWatchClient;
 import software.amazon.awssdk.services.cloudwatch.model.Dimension;
@@ -21,11 +24,9 @@ import software.amazon.awssdk.services.cloudwatchlogs.CloudWatchLogsClient;
 import software.amazon.awssdk.services.cloudwatchlogs.model.GetQueryResultsResponse;
 import software.amazon.awssdk.services.cloudwatchlogs.model.StartQueryRequest;
 
-// DTO 패키지 경로는 실제 위치에 맞게 변경하세요
 import com.example.moyeorak.dto.MetricQueryRequest;
 import com.example.moyeorak.dto.MetricQueryResponse;
 import com.example.moyeorak.dto.LogsQueryRequest;
-
 
 @Service
 @RequiredArgsConstructor
@@ -66,8 +67,18 @@ public class CloudWatchService {
                 .build();
 
         GetMetricDataResponse resp = cw.getMetricData(request);
-        MetricDataResult r = resp.metricDataResults().get(0);
+        List<MetricDataResult> results = resp.metricDataResults();
 
+        // ✅ 빈 결과 처리
+        if (results.isEmpty()) {
+            return new MetricQueryResponse(
+                    "q1",
+                    List.of(),   // values
+                    List.of()    // timestamps
+            );
+        }
+
+        MetricDataResult r = results.get(0);
         return new MetricQueryResponse(
                 r.id(),
                 r.values(),
@@ -75,7 +86,10 @@ public class CloudWatchService {
         );
     }
 
-    public List<Map<String, Object>> runLogsInsights(LogsQueryRequest req) throws InterruptedException {
+    /**
+     * CloudWatch Logs Insights 비동기 실행
+     */
+    public CompletableFuture<List<Map<String, Object>>> runLogsInsightsAsync(LogsQueryRequest req) {
         StartQueryRequest start = StartQueryRequest.builder()
                 .logGroupNames(req.getLogGroupNames())
                 .startTime(req.getStartTime().getEpochSecond())
@@ -86,18 +100,39 @@ public class CloudWatchService {
 
         String queryId = logs.startQuery(start).queryId();
 
-        // 간단 폴링 (실서비스면 비동기 or 웹훅/프론트 재시도 권장)
-        while (true) {
-            GetQueryResultsResponse results = logs.getQueryResults(b -> b.queryId(queryId));
-            String status = results.statusAsString();
-            if ("Complete".equals(status) || "Failed".equals(status) || "Cancelled".equals(status)) {
-                return results.results().stream().map(row -> {
-                    Map<String, Object> m = new LinkedHashMap<>();
-                    row.forEach(f -> m.put(f.field(), f.value()));
-                    return m;
-                }).toList();
-            }
-            Thread.sleep(800);
-        }
+        // ✅ 비동기 폴링 시작 (타임아웃 60초)
+        return pollLogsInsights(queryId, 0, 60_000);
+    }
+
+    /**
+     * Logs Insights 결과를 비동기/재귀적으로 폴링
+     */
+    private CompletableFuture<List<Map<String, Object>>> pollLogsInsights(String queryId,
+                                                                          long elapsedMillis,
+                                                                          long timeoutMillis) {
+        return CompletableFuture
+                .supplyAsync(() -> logs.getQueryResults(b -> b.queryId(queryId)))
+                .thenCompose(results -> {
+                    String status = results.statusAsString();
+                    if ("Complete".equals(status) || "Failed".equals(status) || "Cancelled".equals(status)) {
+                        // 결과 매핑
+                        List<Map<String, Object>> mapped = results.results().stream().map(row -> {
+                            Map<String, Object> m = new LinkedHashMap<>();
+                            row.forEach(f -> m.put(f.field(), f.value()));
+                            return m;
+                        }).toList();
+                        return CompletableFuture.completedFuture(mapped);
+                    }
+
+                    if (elapsedMillis >= timeoutMillis) {
+                        return CompletableFuture.failedFuture(new RuntimeException("Logs Insights query timed out"));
+                    }
+
+                    // ⏳ 800ms 지연 후 재귀 폴링
+                    Executor delayed = CompletableFuture.delayedExecutor(800, TimeUnit.MILLISECONDS);
+                    return CompletableFuture
+                            .runAsync(() -> { /* just delay */ }, delayed)
+                            .thenCompose(v -> pollLogsInsights(queryId, elapsedMillis + 800, timeoutMillis));
+                });
     }
 }

--- a/src/main/java/com/example/moyeorak/service/CloudWatchService.java
+++ b/src/main/java/com/example/moyeorak/service/CloudWatchService.java
@@ -1,0 +1,103 @@
+package com.example.moyeorak.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import software.amazon.awssdk.services.cloudwatch.CloudWatchClient;
+import software.amazon.awssdk.services.cloudwatch.model.Dimension;
+import software.amazon.awssdk.services.cloudwatch.model.GetMetricDataRequest;
+import software.amazon.awssdk.services.cloudwatch.model.GetMetricDataResponse;
+import software.amazon.awssdk.services.cloudwatch.model.Metric;
+import software.amazon.awssdk.services.cloudwatch.model.MetricDataQuery;
+import software.amazon.awssdk.services.cloudwatch.model.MetricDataResult;
+import software.amazon.awssdk.services.cloudwatch.model.MetricStat;
+
+import software.amazon.awssdk.services.cloudwatchlogs.CloudWatchLogsClient;
+import software.amazon.awssdk.services.cloudwatchlogs.model.GetQueryResultsResponse;
+import software.amazon.awssdk.services.cloudwatchlogs.model.StartQueryRequest;
+
+// DTO 패키지 경로는 실제 위치에 맞게 변경하세요
+import com.example.moyeorak.dto.MetricQueryRequest;
+import com.example.moyeorak.dto.MetricQueryResponse;
+import com.example.moyeorak.dto.LogsQueryRequest;
+
+
+@Service
+@RequiredArgsConstructor
+public class CloudWatchService {
+
+    private final CloudWatchClient cw;
+    private final CloudWatchLogsClient logs;
+
+    public MetricQueryResponse getMetricData(MetricQueryRequest req) {
+        // MetricStat 구성
+        List<Dimension> dims = req.getDimensions() == null ? List.of() :
+                req.getDimensions().entrySet().stream()
+                        .map(e -> Dimension.builder().name(e.getKey()).value(e.getValue()).build())
+                        .toList();
+
+        Metric metric = Metric.builder()
+                .namespace(req.getNamespace())
+                .metricName(req.getMetricName())
+                .dimensions(dims)
+                .build();
+
+        MetricStat metricStat = MetricStat.builder()
+                .metric(metric)
+                .stat(req.getStat() == null ? "Average" : req.getStat())
+                .period(req.getPeriod() == null ? 60 : req.getPeriod())
+                .build();
+
+        MetricDataQuery query = MetricDataQuery.builder()
+                .id("q1")
+                .metricStat(metricStat)
+                .returnData(true)
+                .build();
+
+        GetMetricDataRequest request = GetMetricDataRequest.builder()
+                .startTime(req.getStartTime())
+                .endTime(req.getEndTime())
+                .metricDataQueries(List.of(query))
+                .build();
+
+        GetMetricDataResponse resp = cw.getMetricData(request);
+        MetricDataResult r = resp.metricDataResults().get(0);
+
+        return new MetricQueryResponse(
+                r.id(),
+                r.values(),
+                r.timestamps().stream().map(Instant::from).toList()
+        );
+    }
+
+    public List<Map<String, Object>> runLogsInsights(LogsQueryRequest req) throws InterruptedException {
+        StartQueryRequest start = StartQueryRequest.builder()
+                .logGroupNames(req.getLogGroupNames())
+                .startTime(req.getStartTime().getEpochSecond())
+                .endTime(req.getEndTime().getEpochSecond())
+                .queryString(req.getQueryString())
+                .limit(1000)
+                .build();
+
+        String queryId = logs.startQuery(start).queryId();
+
+        // 간단 폴링 (실서비스면 비동기 or 웹훅/프론트 재시도 권장)
+        while (true) {
+            GetQueryResultsResponse results = logs.getQueryResults(b -> b.queryId(queryId));
+            String status = results.statusAsString();
+            if ("Complete".equals(status) || "Failed".equals(status) || "Cancelled".equals(status)) {
+                return results.results().stream().map(row -> {
+                    Map<String, Object> m = new LinkedHashMap<>();
+                    row.forEach(f -> m.put(f.field(), f.value()));
+                    return m;
+                }).toList();
+            }
+            Thread.sleep(800);
+        }
+    }
+}

--- a/src/main/java/com/example/moyeorak/service/FacilityService.java
+++ b/src/main/java/com/example/moyeorak/service/FacilityService.java
@@ -29,39 +29,76 @@ public class FacilityService {
     @Value("${cloudfront.base-url}")
     private String cloudFrontBaseUrl;
 
-    // 과거/입력으로 들어올 수 있는 S3 URL 식별용
-    private static final String S3_HOST_PREFIX = "https://s3-goorm-frontend.s3.ap-northeast-2.amazonaws.com/";
-
     private String formatUsageTime(Facility facility) {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("HH:mm");
         return facility.getUsageStartTime().format(formatter) + " ~ " + facility.getUsageEndTime().format(formatter);
     }
 
     /**
-     * 들어온 값(파일명 혹은 절대 URL)을 '파일명'만 남기도록 정규화
-     * - S3 전체 URL, CloudFront 전체 URL 모두 대응
+     * 들어온 값(파일명/오브젝트 키 혹은 절대 URL)을 '파일명/오브젝트 키'만 남기도록 정규화
+     * - blob:/data: URL은 거부
+     * - http(s) URL은 마지막 '/' 뒤만 추출(쿼리/프래그먼트 제거)
+     * - ':' 문자가 남아 있으면 거부(스킴 혼입 방지)
+     * - 'img/2025/08/foo.jpg' 같은 오브젝트 키는 허용
      */
     private String normalizeToFileName(String raw) {
         if (raw == null || raw.isBlank()) return null;
         String val = raw.trim();
 
-        // 절대 URL이면 마지막 "/" 뒤만 추출
-        if (val.startsWith("http://") || val.startsWith("https://")) {
-            return val.substring(val.lastIndexOf('/') + 1);
+        // 프런트 전용/인라인 데이터는 즉시 거부
+        if (val.startsWith("blob:")) {
+            throw new IllegalArgumentException("blob: URL은 허용되지 않습니다. S3 업로드 후 파일명(또는 오브젝트 키)만 전달하세요.");
         }
-        // 이미 파일명이면 그대로 반환
+        if (val.startsWith("data:")) {
+            throw new IllegalArgumentException("data: URL은 허용되지 않습니다. S3 업로드 후 파일명(또는 오브젝트 키)만 전달하세요.");
+        }
+
+        // 절대 URL 처리
+        if (val.startsWith("http://") || val.startsWith("https://")) {
+            int qm = val.indexOf('?');
+            int hash = val.indexOf('#');
+            int cut = val.length();
+            if (qm >= 0) cut = Math.min(cut, qm);
+            if (hash >= 0) cut = Math.min(cut, hash);
+
+            String withoutQuery = val.substring(0, cut);
+            String fileName = withoutQuery.substring(withoutQuery.lastIndexOf('/') + 1);
+
+            if (fileName.isBlank()) {
+                throw new IllegalArgumentException("유효하지 않은 이미지 URL입니다(파일명이 비어 있음).");
+            }
+            if (fileName.contains(":")) {
+                throw new IllegalArgumentException("이미지 파일명에 ':' 문자는 허용되지 않습니다.");
+            }
+            return fileName;
+        }
+
+        // 이미 파일명(또는 오브젝트 키)인 경우: 간단 검증
+        if (val.contains(":")) {
+            throw new IllegalArgumentException("이미지 파일명에 ':' 문자는 허용되지 않습니다.");
+        }
+        // 앞/뒤 불필요한 '/' 제거는 하지 않음(키의 일부일 수 있으므로), 공백만 제거
         return val;
     }
 
     /**
-     * 응답용 절대경로: CloudFront 베이스 + 파일명
-     * (들어온 값이 절대 URL이든 파일명이든 결과는 CloudFront 절대경로로 통일)
+     * 응답용 절대경로: CloudFront 베이스 + 파일명/키
+     * cloudFrontBaseUrl의 슬래시 유무와 상관없이 안전하게 결합
      */
     private String toCloudFrontUrl(String fileNameOrUrl) {
         if (fileNameOrUrl == null || fileNameOrUrl.isBlank()) return null;
-        String fileName = normalizeToFileName(fileNameOrUrl);
-        // cloudFrontBaseUrl이 /로 끝나지 않는다고 가정
-        return cloudFrontBaseUrl + "/" + fileName;
+        String fileNameOrKey = normalizeToFileName(fileNameOrUrl); // blob/data 차단 포함
+        return joinUrl(cloudFrontBaseUrl, fileNameOrKey);
+    }
+
+    private String joinUrl(String base, String path) {
+        if (base.endsWith("/")) {
+            if (path.startsWith("/")) return base + path.substring(1);
+            return base + path;
+        } else {
+            if (path.startsWith("/")) return base + path;
+            return base + "/" + path;
+        }
     }
 
     @Transactional
@@ -74,7 +111,7 @@ public class FacilityService {
                 .address(dto.getAddress())
                 .location(dto.getLocation())
                 .contact(dto.getContact())
-                // 저장은 파일명만 (절대 URL이 들어와도 파일명으로 정규화)
+                // 저장은 파일명/오브젝트 키만 (절대 URL이 들어와도 정규화)
                 .imageUrl(normalizeToFileName(dto.getImageUrl()))
                 .capacity(dto.getCapacity())
                 .description(dto.getDescription())
@@ -86,7 +123,7 @@ public class FacilityService {
 
         Facility saved = facilityRepository.save(facility);
 
-        // 응답은 CloudFront 절대경로로 내려줌
+        // 응답은 CloudFront 절대경로로 통일
         return FacilityDto.builder()
                 .id(saved.getId())
                 .name(saved.getName())
@@ -145,7 +182,7 @@ public class FacilityService {
         if (dto.getAddress() != null) facility.setAddress(dto.getAddress());
         if (dto.getContact() != null) facility.setContact(dto.getContact());
         if (dto.getImageUrl() != null) {
-            // 업데이트 시에도 DB에는 파일명만 저장
+            // 업데이트 시에도 DB에는 파일명/오브젝트 키만 저장
             facility.setImageUrl(normalizeToFileName(dto.getImageUrl()));
         }
         if (dto.getCapacity() != null) facility.setCapacity(dto.getCapacity());
@@ -164,7 +201,7 @@ public class FacilityService {
             facility.setRegion(region);
         }
 
-        // 응답은 CloudFront 절대경로로 내려줌
+        // 응답은 CloudFront 절대경로로 통일
         return FacilityDto.builder()
                 .id(facility.getId())
                 .name(facility.getName())

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -16,7 +16,7 @@ aws.use.default-credentials=${AWS_USE_DEFAULT_CREDENTIALS:false}
 # ===============================
 # = AWS REGION (CloudWatch/Logs ?)
 # ===============================
-# ???? ???? ??? ap-northeast-2 ??? ??
+# Set AWS region to ap-northeast-2 (used for CloudWatch/Logs)
 aws.region=ap-northeast-2
 
 # ===============================

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,8 +4,6 @@ spring.application.name=moyeorak
 # = DATABASE CONNECTION SETTINGS
 # ===============================
 spring.datasource.url=${SPRING_DATASOURCE_URL:jdbc:mysql://localhost:3306/moyeorak_db?useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8}
-#spring.datasource.url=jdbc:mysql://localhost:3306/moyeorak_db?useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
-#spring.datasource.url=jdbc:mysql://goorm-mysql.c92y0sa8e7t2.ap-northeast-2.rds.amazonaws.com:3306/moyeorak_db?useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
 spring.datasource.username=choi
 spring.datasource.password=1q2w3e4r!!
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
@@ -16,6 +14,12 @@ spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 aws.use.default-credentials=${AWS_USE_DEFAULT_CREDENTIALS:false}
 
 # ===============================
+# = AWS REGION (CloudWatch/Logs ?)
+# ===============================
+# ???? ???? ??? ap-northeast-2 ??? ??
+aws.region=ap-northeast-2
+
+# ===============================
 # = AWS REDIS SETTINGS
 # ===============================
 #spring.redis.host=goorm-redis.m98tqf.ng.0001.apn2.cache.amazonaws.com
@@ -23,7 +27,7 @@ aws.use.default-credentials=${AWS_USE_DEFAULT_CREDENTIALS:false}
 #spring.cache.type=redis
 
 # ===============================
-# = AWS S3 SETTINGS    =
+# = AWS S3 SETTINGS
 # ===============================
 cloud.aws.credentials.access-key=${AWS_ACCESS_KEY}
 cloud.aws.credentials.secret-key=${AWS_SECRET_KEY}
@@ -33,7 +37,7 @@ cloud.aws.stack.auto=false
 cloudfront.base-url=https://www.moyeorak.cloud/img
 
 # ===============================
-# = AWS SQS SETTINGS    =
+# = AWS SQS SETTINGS
 # ===============================
 sqs.queue.url=https://sqs.ap-northeast-2.amazonaws.com/004407157704/goorm-enrollment-sqs
 spring.cloud.aws.sqs.enabled=true


### PR DESCRIPTION
## What
- Spring Security를 **무상태(Stateless)** 로 설정하여 JWT 인증이 요청마다 확실히 적용되도록 수정
  - `SecurityConfig`에 `sessionManagement(SessionCreationPolicy.STATELESS)` 추가
  - `JwtAuthFilter`는 기존과 동일하게 체인 앞단에 배치( `addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class)` )

## Why
- `/api/cloudwatch/logs/query` 호출 시 토큰은 헤더로 전달되지만,
  컨트롤러 진입 전(시큐리티 필터 단계)에서 인증이 성립하지 않아 **401 Unauthorized** 발생
- 세션 의존 가능성을 제거하고, 매 요청마다 JWT로 인증되도록 무상태 정책을 명시

## Scope / Impact
- **API 스펙 변경 없음**, 응답 포맷 동일
- 프론트엔드 변경 불필요 (Authorization: Bearer <token> 그대로 사용)
- 공개/관리자 권한 정책은 기존과 동일

## Test
1) 유효 토큰으로 호출 → 200 OK
   ```bash
   curl -i -X POST "http://<HOST>:8080/api/cloudwatch/logs/query" \
     -H "Authorization: Bearer <JWT>" \
     -H "Content-Type: application/json" \
     --data '{"logGroupNames":["/aws/lambda/your-log-group"],"queryString":"fields @timesta