### PR TITLE
fix: S3 presigner bean/config & admin main image service using Respon…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ dependencies {
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
 
     // DB Driver
-    runtimeOnly 'com.mysql:mysql-connector-j'  // 9.x 사용 중 (OK)
+    runtimeOnly 'com.mysql:mysql-connector-j'  // 9.x OK
 
     // --- Test ---
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
@@ -56,10 +56,10 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
     // --- AWS Spring Cloud (SQS) ---
-    // spring-cloud-aws BOM (starter 버전 정합성만 관리; SDK 버전은 아래에서 별도 BOM으로 고정)
+    // spring-cloud-aws BOM
     implementation platform('io.awspring.cloud:spring-cloud-aws-dependencies:3.0.2')
 
-    // starter가 끌고오는 software.amazon.awssdk(구버전)를 제외하고, 아래에서 우리가 지정한 BOM 버전을 사용
+    // starter가 끌고오는 SDK 버전 고정 방지
     implementation('io.awspring.cloud:spring-cloud-aws-starter-sqs') {
         exclude group: 'software.amazon.awssdk'
     }
@@ -72,7 +72,12 @@ dependencies {
     implementation 'software.amazon.awssdk:cloudwatch'
     implementation 'software.amazon.awssdk:cloudwatchlogs'
 
-    // 필요 시 추가 예: implementation 'software.amazon.awssdk:sts' 등
+    // ✅ 추가: S3 (Presigner/PutObjectRequest 포함)
+    implementation 'software.amazon.awssdk:s3'
+
+    // (선택) 대용량/비동기 업로드 필요 시
+    // implementation 'software.amazon.awssdk:s3-transfer-manager'
+    // implementation 'software.amazon.awssdk:sts' // 필요한 경우만
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/moyeorak/config/AwsClientsConfig.java
+++ b/src/main/java/com/example/moyeorak/config/AwsClientsConfig.java
@@ -1,19 +1,20 @@
 package com.example.moyeorak.config;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import lombok.extern.slf4j.Slf4j;
-
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.cloudwatch.CloudWatchClient;
 import software.amazon.awssdk.services.cloudwatchlogs.CloudWatchLogsClient;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 @Slf4j
 @Configuration
 public class AwsClientsConfig {
 
-    // application.properties 에 aws.region이 없을 때 기본값으로 ap-northeast-2 사용
+    // application.yml(.properties)에 aws.region 없으면 기본 ap-northeast-2
     @Value("${aws.region:ap-northeast-2}")
     private String region;
 
@@ -21,7 +22,8 @@ public class AwsClientsConfig {
     public CloudWatchClient cloudWatchClient() {
         CloudWatchClient client = CloudWatchClient.builder()
                 .region(Region.of(region))
-                .build(); // 자격증명: 기본 프로바이더 체인(IAM Role/환경변수/SharedCredentials)
+                .credentialsProvider(DefaultCredentialsProvider.create())
+                .build(); // 자격증명: 기본 체인(IAM Role/Env/Shared Credentials)
         log.info("[CloudWatch] region={}", region);
         return client;
     }
@@ -30,8 +32,23 @@ public class AwsClientsConfig {
     public CloudWatchLogsClient cloudWatchLogsClient() {
         CloudWatchLogsClient client = CloudWatchLogsClient.builder()
                 .region(Region.of(region))
+                .credentialsProvider(DefaultCredentialsProvider.create())
                 .build();
         log.info("[CloudWatchLogs] region={}", region);
         return client;
+    }
+
+    /**
+     * S3 Presigner 빈 등록 (필수)
+     * destroyMethod="close"로 컨텍스트 종료 시 안전하게 자원 해제
+     */
+    @Bean(destroyMethod = "close")
+    public S3Presigner s3Presigner() {
+        S3Presigner presigner = S3Presigner.builder()
+                .region(Region.of(region))
+                .credentialsProvider(DefaultCredentialsProvider.create())
+                .build();
+        log.info("[S3Presigner] region={}", region);
+        return presigner;
     }
 }

--- a/src/main/java/com/example/moyeorak/controller/admin/AdminMainImageController.java
+++ b/src/main/java/com/example/moyeorak/controller/admin/AdminMainImageController.java
@@ -35,28 +35,42 @@ public class AdminMainImageController {
 
     @Operation(summary = "홍보물 리스트 조회")
     @GetMapping
-    public ResponseEntity<List<AdminMainImageResponse>> getMainImages(HttpServletRequest request) {
+    public ResponseEntity<List<AdminMainImageResponse>> getMainImages(HttpServletRequest httpRequest) {
         log.info("홍보물 리스트 조회 요청");
-        List<AdminMainImageResponse> list = adminMainImageService.getMainImages(request);
+        List<AdminMainImageResponse> list = adminMainImageService.getMainImages(httpRequest);
         log.info("홍보물 리스트 조회 완료: {}건", list.size());
         return ResponseEntity.ok(list);
     }
 
     @Operation(summary = "홍보물 삭제")
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deleteMainImage(@PathVariable Long id) {
+    public ResponseEntity<Void> deleteMainImage(@PathVariable Long id, HttpServletRequest httpRequest) {
         log.info("홍보물 삭제 요청: id={}", id);
-        adminMainImageService.deleteById(id);
+        adminMainImageService.deleteById(id, httpRequest); // ✅ HttpServletRequest 전달
         log.info("홍보물 삭제 완료: id={}", id);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.noContent().build(); // 204
     }
 
     @Operation(summary = "홍보물 순서 및 표시여부 전체 수정")
     @PatchMapping
-    public ResponseEntity<Void> updateMainImages(@RequestBody List<AdminMainImageUpdateRequest> requestList) {
+    public ResponseEntity<Void> updateMainImages(
+            @RequestBody List<AdminMainImageUpdateRequest> requestList,
+            HttpServletRequest httpRequest
+    ) {
         log.info("홍보물 순서/표시여부 전체 수정 요청: {}건", requestList.size());
-        adminMainImageService.updateMainImages(requestList);
+        adminMainImageService.updateMainImages(requestList, httpRequest); // ✅ HttpServletRequest 전달
         log.info("홍보물 순서/표시여부 전체 수정 완료");
         return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "S3 업로드용 Presigned URL 발급")
+    @GetMapping("/presigned-url")
+    public ResponseEntity<String> getPresignedUrl(
+            @RequestParam String filename,
+            @RequestParam String filetype,
+            HttpServletRequest httpRequest
+    ) {
+        String url = adminMainImageService.createPresignedPutUrl(filename, filetype, httpRequest);
+        return ResponseEntity.ok(url);
     }
 }

--- a/src/main/java/com/example/moyeorak/jwt/JwtAuthFilter.java
+++ b/src/main/java/com/example/moyeorak/jwt/JwtAuthFilter.java
@@ -1,8 +1,7 @@
 package com.example.moyeorak.jwt;
 
+import com.example.moyeorak.repository.UserRepository;
 import io.jsonwebtoken.ExpiredJwtException;
-import io.jsonwebtoken.MalformedJwtException;
-import io.jsonwebtoken.SignatureException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -18,8 +17,6 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
-import java.security.Principal;
-import java.util.Arrays;
 import java.util.List;
 
 @Slf4j
@@ -27,124 +24,85 @@ import java.util.List;
 @RequiredArgsConstructor
 public class JwtAuthFilter extends OncePerRequestFilter {
 
-    private final JwtProvider jwtProvider;
+    private static final long UNKNOWN_USER_ID = -1L;
 
-    /** 로컬/개발에서만 임시 우회 허용 (기본 false) */
+    private final JwtProvider jwtProvider;
+    private final UserRepository userRepository;
+
     @Value("${security.jwt.dev-bypass:false}")
     private boolean devBypass;
 
-    /** 스웨거/헬스/정적 리소스 등은 필터를 건너뜀 */
     @Override
-    protected boolean shouldNotFilter(HttpServletRequest request) {
-        String path = request.getRequestURI();
-        return "OPTIONS".equalsIgnoreCase(request.getMethod())
-                || path.startsWith("/actuator")
-                || path.startsWith("/v3/api-docs")
-                || path.startsWith("/swagger-ui")
-                || path.startsWith("/swagger-ui.html");
-    }
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
 
-    @Override
-    protected void doFilterInternal(HttpServletRequest request,
-                                    HttpServletResponse response,
-                                    FilterChain filterChain)
-            throws ServletException, IOException {
-
-        String header = request.getHeader("Authorization");
-
+        String token = null;
         try {
-            if (header != null && header.startsWith("Bearer ")) {
-                String token = header.substring(7);
+            token = jwtProvider.resolveToken(request);
 
-                if (jwtProvider.validateToken(token)) {
-                    // ---- 여기부터 완화된 인증 세팅 ----
-                    String email = jwtProvider.getEmail(token);
-                    if (email == null) {
-                        // sub를 이메일로 사용하는 케이스 대응
-                        email = jwtProvider.getSubject(token);
-                    }
-
-                    Long userId = jwtProvider.getUserId(token);
-                    if (userId == null) userId = -1L; // placeholder
-
-                    String roleRaw = jwtProvider.getRole(token);
-                    if (roleRaw == null || roleRaw.isBlank()) roleRaw = "USER";
-
-                    var authorities = Arrays.stream(roleRaw.split(","))
-                            .map(String::trim)
-                            .filter(s -> !s.isBlank())
-                            .map(r -> r.startsWith("ROLE_") ? r : "ROLE_" + r.toUpperCase())
-                            .map(SimpleGrantedAuthority::new)
-                            .toList();
-
-                    if (email != null && SecurityContextHolder.getContext().getAuthentication() == null) {
-                        var principal = new SimpleUserPrincipal(userId, email);
-                        var auth = new UsernamePasswordAuthenticationToken(principal, null, authorities);
-                        auth.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
-                        SecurityContextHolder.getContext().setAuthentication(auth);
-                        log.debug("✅ JWT 인증 성공 - userId: {}, email: {}, roles: {}", userId, email, authorities);
-                    }
-                } else {
-                    if (devBypass) {
-                        bypassAsTempUser(request, "검증실패(개발우회)");
-                    } else {
-                        response.setHeader("WWW-Authenticate", "Bearer error=\"invalid_token\"");
-                        response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "유효하지 않은 JWT 토큰입니다.");
-                        return;
-                    }
+            if (token != null && jwtProvider.validateToken(token)) {
+                String email = jwtProvider.getEmail(token);
+                if (email == null) {
+                    // Handle case where sub is used as email
+                    email = jwtProvider.getSubject(token);
                 }
 
+                String role = jwtProvider.getRole(token);
+                if (role == null || role.isBlank()) {
+                    role = "USER";
+                }
+
+                var authority = new SimpleGrantedAuthority("ROLE_" + role.toUpperCase());
+                var authorities = List.of(authority);
+
+                Long userId = jwtProvider.getUserId(token);
+                if (userId == null) {
+                    userId = UNKNOWN_USER_ID; // explicit placeholder
+                }
+
+                // Optional: load user to enrich context (safe to be null)
+                var user = (email != null) ? userRepository.findByEmail(email).orElse(null) : null;
+
+                var principal = (user != null) ? user : email; // fallback to email string
+                var auth = new UsernamePasswordAuthenticationToken(principal, null, authorities);
+                auth.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                SecurityContextHolder.getContext().setAuthentication(auth);
+
+                log.debug("✅ JWT authentication successful - userId: {}, email: {}, roles: {}",
+                        userId, email, authorities);
             } else {
                 if (devBypass) {
-                    bypassAsTempUser(request, "헤더없음/비Bearer(개발우회)");
+                    bypassAsTempUser(request, "Validation failed (dev bypass)");
                 }
             }
-
-            filterChain.doFilter(request, response);
-
         } catch (ExpiredJwtException e) {
+            log.debug("JWT expired: {}", e.getMessage());
             if (devBypass) {
-                bypassAsTempUser(request, "만료(개발우회)");
-                filterChain.doFilter(request, response);
-            } else {
-                log.warn("❌ AccessToken 만료: {}", e.getMessage());
-                response.setHeader("WWW-Authenticate", "Bearer error=\"invalid_token\", error_description=\"expired\"");
-                response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "AccessToken이 만료되었습니다.");
-            }
-        } catch (SignatureException | MalformedJwtException e) {
-            if (devBypass) {
-                bypassAsTempUser(request, "서명/형식 오류(개발우회)");
-                filterChain.doFilter(request, response);
-            } else {
-                log.warn("❌ 잘못된 JWT 서명 또는 토큰 형식: {}", e.getMessage());
-                response.setHeader("WWW-Authenticate", "Bearer error=\"invalid_token\"");
-                response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "유효하지 않은 JWT 토큰입니다.");
+                bypassAsTempUser(request, "Expired (dev bypass)");
             }
         } catch (Exception e) {
+            log.debug("JWT parse/validation error: {}", e.getMessage());
             if (devBypass) {
-                bypassAsTempUser(request, "기타오류(개발우회)");
-                filterChain.doFilter(request, response);
-            } else {
-                log.warn("❌ JWT 검증 중 기타 오류: {}", e.getMessage());
-                response.setHeader("WWW-Authenticate", "Bearer");
-                response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "JWT 인증에 실패했습니다.");
+                bypassAsTempUser(request, "Signature/format error (dev bypass)");
             }
         }
+
+        if (token == null && devBypass && SecurityContextHolder.getContext().getAuthentication() == null) {
+            // No header/non-Bearer etc.
+            bypassAsTempUser(request, "No header/non-Bearer (dev bypass)");
+        }
+
+        filterChain.doFilter(request, response);
     }
 
     private void bypassAsTempUser(HttpServletRequest request, String reason) {
-        var authorities = List.of(new SimpleGrantedAuthority("ROLE_USER"));
-        var principal = new SimpleUserPrincipal(-1L, "temp@local");
-
-        var auth = new UsernamePasswordAuthenticationToken(principal, null, authorities);
+        var authorities = List.of(new SimpleGrantedAuthority("ROLE_GUEST"));
+        var auth = new UsernamePasswordAuthenticationToken("temp-user", null, authorities);
         auth.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
         SecurityContextHolder.getContext().setAuthentication(auth);
-
-        log.warn("⚠️ JWT 우회 인증 적용 [{}] - tempUser로 진행", reason);
-    }
-
-    /** 컨트롤러에서 @AuthenticationPrincipal(expression = "id") / ("email") 로 접근 가능한 Principal */
-    public record SimpleUserPrincipal(Long id, String email) implements Principal {
-        @Override public String getName() { return email != null ? email : String.valueOf(id); }
+        log.debug("⚠️ Dev bypass applied - reason: {}", reason);
     }
 }

--- a/src/main/java/com/example/moyeorak/jwt/JwtAuthFilter.java
+++ b/src/main/java/com/example/moyeorak/jwt/JwtAuthFilter.java
@@ -1,7 +1,5 @@
 package com.example.moyeorak.jwt;
 
-import com.example.moyeorak.repository.UserRepository;
-import com.example.moyeorak.security.CustomUserDetails;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.SignatureException;
@@ -11,13 +9,17 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.security.Principal;
+import java.util.Arrays;
 import java.util.List;
 
 @Slf4j
@@ -26,69 +28,123 @@ import java.util.List;
 public class JwtAuthFilter extends OncePerRequestFilter {
 
     private final JwtProvider jwtProvider;
-    private final UserRepository userRepository;
+
+    /** 로컬/개발에서만 임시 우회 허용 (기본 false) */
+    @Value("${security.jwt.dev-bypass:false}")
+    private boolean devBypass;
+
+    /** 스웨거/헬스/정적 리소스 등은 필터를 건너뜀 */
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        String path = request.getRequestURI();
+        return "OPTIONS".equalsIgnoreCase(request.getMethod())
+                || path.startsWith("/actuator")
+                || path.startsWith("/v3/api-docs")
+                || path.startsWith("/swagger-ui")
+                || path.startsWith("/swagger-ui.html");
+    }
 
     @Override
-    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain)
             throws ServletException, IOException {
-
-        if ("OPTIONS".equalsIgnoreCase(request.getMethod())) {
-            filterChain.doFilter(request, response);
-            return;
-        }
 
         String header = request.getHeader("Authorization");
 
-        if (header != null && header.startsWith("Bearer ")) {
-            String token = header.substring(7);
+        try {
+            if (header != null && header.startsWith("Bearer ")) {
+                String token = header.substring(7);
 
-            try {
                 if (jwtProvider.validateToken(token)) {
+                    // ---- 여기부터 완화된 인증 세팅 ----
                     String email = jwtProvider.getEmail(token);
-                    String role = jwtProvider.getRole(token);
+                    if (email == null) {
+                        // sub를 이메일로 사용하는 케이스 대응
+                        email = jwtProvider.getSubject(token);
+                    }
 
-                    if (email != null && role != null &&
-                            SecurityContextHolder.getContext().getAuthentication() == null) {
+                    Long userId = jwtProvider.getUserId(token);
+                    if (userId == null) userId = -1L; // placeholder
 
-                        var user = userRepository.findByEmail(email).orElse(null);
+                    String roleRaw = jwtProvider.getRole(token);
+                    if (roleRaw == null || roleRaw.isBlank()) roleRaw = "USER";
 
-                        if (user != null) {
-                            String authority = "ROLE_" + role.toUpperCase();
-                            var authorities = List.of(new SimpleGrantedAuthority(authority));
+                    var authorities = Arrays.stream(roleRaw.split(","))
+                            .map(String::trim)
+                            .filter(s -> !s.isBlank())
+                            .map(r -> r.startsWith("ROLE_") ? r : "ROLE_" + r.toUpperCase())
+                            .map(SimpleGrantedAuthority::new)
+                            .toList();
 
-                            var userDetails = new CustomUserDetails(
-                                    user.getId(),
-                                    user.getEmail(),
-                                    user.getPassword(),
-                                    authorities
-                            );
-
-                            var auth = new UsernamePasswordAuthenticationToken(userDetails, null, authorities);
-                            SecurityContextHolder.getContext().setAuthentication(auth);
-
-                            log.debug("✅ JWT 인증 성공 - 사용자: {}, 권한: {}", email, authority);
-                        } else {
-                            log.warn("❌ 사용자 DB 조회 실패 - email: {}", email);
-                        }
+                    if (email != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+                        var principal = new SimpleUserPrincipal(userId, email);
+                        var auth = new UsernamePasswordAuthenticationToken(principal, null, authorities);
+                        auth.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                        SecurityContextHolder.getContext().setAuthentication(auth);
+                        log.debug("✅ JWT 인증 성공 - userId: {}, email: {}, roles: {}", userId, email, authorities);
+                    }
+                } else {
+                    if (devBypass) {
+                        bypassAsTempUser(request, "검증실패(개발우회)");
+                    } else {
+                        response.setHeader("WWW-Authenticate", "Bearer error=\"invalid_token\"");
+                        response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "유효하지 않은 JWT 토큰입니다.");
+                        return;
                     }
                 }
-            } catch (ExpiredJwtException e) {
-                log.warn("❌ AccessToken 만료: {}", e.getMessage());
-                response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "AccessToken이 만료되었습니다.");
-                return;
-            } catch (SignatureException | MalformedJwtException e) {
-                log.warn("❌ 잘못된 JWT 서명 또는 토큰 형식 오류: {}", e.getMessage());
-                response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "유효하지 않은 JWT 토큰입니다.");
-                return;
-            } catch (Exception e) {
-                log.warn("❌ JWT 검증 중 기타 오류: {}", e.getMessage());
-                response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "JWT 인증에 실패했습니다.");
-                return;
-            }
-        } else {
-            //log.debug("ℹ️ Authorization 헤더 없음 또는 Bearer 토큰 형식 아님");
-        }
 
-        filterChain.doFilter(request, response);
+            } else {
+                if (devBypass) {
+                    bypassAsTempUser(request, "헤더없음/비Bearer(개발우회)");
+                }
+            }
+
+            filterChain.doFilter(request, response);
+
+        } catch (ExpiredJwtException e) {
+            if (devBypass) {
+                bypassAsTempUser(request, "만료(개발우회)");
+                filterChain.doFilter(request, response);
+            } else {
+                log.warn("❌ AccessToken 만료: {}", e.getMessage());
+                response.setHeader("WWW-Authenticate", "Bearer error=\"invalid_token\", error_description=\"expired\"");
+                response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "AccessToken이 만료되었습니다.");
+            }
+        } catch (SignatureException | MalformedJwtException e) {
+            if (devBypass) {
+                bypassAsTempUser(request, "서명/형식 오류(개발우회)");
+                filterChain.doFilter(request, response);
+            } else {
+                log.warn("❌ 잘못된 JWT 서명 또는 토큰 형식: {}", e.getMessage());
+                response.setHeader("WWW-Authenticate", "Bearer error=\"invalid_token\"");
+                response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "유효하지 않은 JWT 토큰입니다.");
+            }
+        } catch (Exception e) {
+            if (devBypass) {
+                bypassAsTempUser(request, "기타오류(개발우회)");
+                filterChain.doFilter(request, response);
+            } else {
+                log.warn("❌ JWT 검증 중 기타 오류: {}", e.getMessage());
+                response.setHeader("WWW-Authenticate", "Bearer");
+                response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "JWT 인증에 실패했습니다.");
+            }
+        }
+    }
+
+    private void bypassAsTempUser(HttpServletRequest request, String reason) {
+        var authorities = List.of(new SimpleGrantedAuthority("ROLE_USER"));
+        var principal = new SimpleUserPrincipal(-1L, "temp@local");
+
+        var auth = new UsernamePasswordAuthenticationToken(principal, null, authorities);
+        auth.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+        SecurityContextHolder.getContext().setAuthentication(auth);
+
+        log.warn("⚠️ JWT 우회 인증 적용 [{}] - tempUser로 진행", reason);
+    }
+
+    /** 컨트롤러에서 @AuthenticationPrincipal(expression = "id") / ("email") 로 접근 가능한 Principal */
+    public record SimpleUserPrincipal(Long id, String email) implements Principal {
+        @Override public String getName() { return email != null ? email : String.valueOf(id); }
     }
 }

--- a/src/main/java/com/example/moyeorak/jwt/JwtProvider.java
+++ b/src/main/java/com/example/moyeorak/jwt/JwtProvider.java
@@ -1,6 +1,11 @@
 package com.example.moyeorak.jwt;
 
-import io.jsonwebtoken.*;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
 import jakarta.servlet.http.HttpServletRequest;
@@ -11,97 +16,231 @@ import org.springframework.stereotype.Component;
 import java.nio.charset.StandardCharsets;
 import java.security.Key;
 import java.util.Date;
+import java.util.List;
+import java.util.Objects;
 
 @Slf4j
 @Component
 public class JwtProvider {
 
     @Value("${jwt.secret}")
-    private String secret;
+    private String secret; // HS256용 비밀키 (Base64 권장, 32바이트 이상)
 
-    private Key secretKey;
+    @Value("${jwt.issuer:}")
+    private String issuer; // 선택값
+
+    @Value("${jwt.access-token.ttl-seconds:1800}")   // 기본 30분
+    private long accessTokenTtlSeconds;
+
+    @Value("${jwt.refresh-token.ttl-seconds:1209600}") // 기본 14일 = 60*60*24*14
+    private long refreshTokenTtlSeconds;
+
+    private Key key;
 
     @PostConstruct
-    public void init() {
-        this.secretKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+    void init() {
+        // Base64로 우선 시도, 실패하면 raw bytes 사용
+        try {
+            byte[] decoded = Decoders.BASE64.decode(secret);
+            this.key = Keys.hmacShaKeyFor(decoded);
+        } catch (Exception e) {
+            byte[] raw = secret.getBytes(StandardCharsets.UTF_8);
+            if (raw.length < 32) {
+                log.warn("jwt.secret 길이가 짧습니다(>=32 bytes 권장). 현재: {} bytes", raw.length);
+            }
+            this.key = Keys.hmacShaKeyFor(raw);
+        }
     }
 
-    // ✅ 액세스 토큰 생성
+    /* ====== Token Generation ====== */
+
+    /** Access Token 생성 (subject=email, roles=role 문자열) */
     public String generateToken(String email, String role) {
-        Date now = new Date();
-        Date expiryDate = new Date(now.getTime() + 1000L * 60 * 30); // 30분
+        long now = System.currentTimeMillis();
+        long expMillis = now + (accessTokenTtlSeconds * 1000L);
 
-        return Jwts.builder()
+        var builder = Jwts.builder()
                 .setSubject(email)
-                .claim("roles", role)
-                .setIssuedAt(now)
-                .setExpiration(expiryDate)
-                .signWith(secretKey, SignatureAlgorithm.HS256)
-                .compact();
+                .claim("roles", role)              // 프론트/기존 토큰과 호환(roles: "ADMIN")
+                .setIssuedAt(new Date(now))
+                .setExpiration(new Date(expMillis));
+
+        if (issuer != null && !issuer.isBlank()) {
+            builder.setIssuer(issuer);
+        }
+
+        // HS256 서명
+        return builder.signWith(key, SignatureAlgorithm.HS256).compact();
     }
 
-    // ✅ 리프레시 토큰 생성
+    /** Refresh Token 생성 (subject=email, 권한 등 부가클레임 없이 긴 만료) */
     public String generateRefreshToken(String email) {
-        Date now = new Date();
-        Date expiryDate = new Date(now.getTime() + 1000L * 60 * 30); // 30분
+        long now = System.currentTimeMillis();
+        long expMillis = now + (refreshTokenTtlSeconds * 1000L);
 
-        return Jwts.builder()
+        var builder = Jwts.builder()
                 .setSubject(email)
-                .setIssuedAt(now)
-                .setExpiration(expiryDate)
-                .signWith(secretKey, SignatureAlgorithm.HS256)
-                .compact();
+                .setIssuedAt(new Date(now))
+                .setExpiration(new Date(expMillis));
+
+        if (issuer != null && !issuer.isBlank()) {
+            builder.setIssuer(issuer);
+        }
+
+        return builder.signWith(key, SignatureAlgorithm.HS256).compact();
     }
 
-    // ✅ 이메일 추출
+    /* ====== Public API ====== */
+
+    /** 토큰 유효성 검증(서명/만료 등) */
+    public boolean validateToken(String token) {
+        try {
+            parseClaims(token); // 파싱되면 유효
+            return true;
+        } catch (ExpiredJwtException e) {
+            log.debug("JWT expired: {}", e.getMessage());
+            return false;
+        } catch (JwtException | IllegalArgumentException e) {
+            log.debug("Invalid JWT: {}", e.getMessage());
+            return false;
+        }
+    }
+
+    /** userId 클레임(숫자) 또는 subject가 숫자면 반환 */
+    public Long getUserId(String token) {
+        try {
+            Claims c = parseClaims(token);
+            Long id = claimAsLong(c, "id");
+            if (id != null) return id;
+
+            id = claimAsLong(c, "userId");
+            if (id != null) return id;
+
+            id = claimAsLong(c, "uid");
+            if (id != null) return id;
+
+            // sub가 숫자면 그것도 허용
+            String sub = c.getSubject();
+            if (sub != null) {
+                try { return Long.parseLong(sub); } catch (NumberFormatException ignored) {}
+            }
+            return null;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    /** email 클레임 또는 subject(이메일 형태면) */
     public String getEmail(String token) {
+        try {
+            Claims c = parseClaims(token);
+            String email = claimAsString(c, "email");
+            if (email != null) return email;
+
+            String sub = c.getSubject();
+            if (sub != null && sub.contains("@")) return sub;
+
+            return null;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    /** subject 그대로 반환 */
+    public String getSubject(String token) {
         try {
             return parseClaims(token).getSubject();
         } catch (Exception e) {
-            log.warn("이메일 추출 실패: {}", e.getMessage());
             return null;
         }
     }
 
-    // ✅ 권한(role) 추출
+    /** 단일 role 또는 roles 첫 번째 값(문자열/리스트/배열 모두 지원) */
     public String getRole(String token) {
         try {
-            return parseClaims(token).get("roles", String.class);
+            Claims c = parseClaims(token);
+
+            // 1) role(단수)
+            String role = claimAsString(c, "role");
+            if (role != null) return role;
+
+            // 2) roles(복수)
+            Object roles = c.get("roles");
+            if (roles == null) return null;
+
+            if (roles instanceof String s) {
+                // "ADMIN" 또는 "ADMIN,USER"
+                String first = s.split(",")[0].trim();
+                return first.isEmpty() ? null : first;
+            }
+            if (roles instanceof List<?> list && !list.isEmpty()) {
+                Object first = list.get(0);
+                return first == null ? null : String.valueOf(first).trim();
+            }
+            if (roles.getClass().isArray()) {
+                int len = java.lang.reflect.Array.getLength(roles);
+                Object first = len > 0 ? java.lang.reflect.Array.get(roles, 0) : null;
+                return first == null ? null : String.valueOf(first).trim();
+            }
+            return null;
         } catch (Exception e) {
-            log.warn("권한 추출 실패: {}", e.getMessage());
             return null;
         }
     }
 
-    // ✅ 토큰 유효성 검증 (예외는 상위로 throw하여 JwtAuthFilter에서 처리)
-    public boolean validateToken(String token) {
+    /** (선택) regionId 클레임을 쓰고 싶다면 사용 */
+    public Long getRegionId(String token) {
         try {
-            parseClaims(token);
-            return true;
-        } catch (ExpiredJwtException e) {
-            log.warn("만료된 JWT: {}", e.getMessage());
-            return false;
-        } catch (JwtException | IllegalArgumentException e) {
-            log.warn("JWT 유효성 검증 실패: {}", e.getMessage());
-            return false;
+            Claims c = parseClaims(token);
+            return claimAsLong(c, "regionId");
+        } catch (Exception e) {
+            return null;
         }
     }
 
-    // ✅ 토큰에서 Claims 파싱
-    private Claims parseClaims(String token) {
-        return Jwts.parserBuilder()
-                .setSigningKey(secretKey)
-                .build()
-                .parseClaimsJws(token)
-                .getBody();
-    }
-
-    // ✅ 요청 헤더에서 Bearer 토큰 추출
-    public String resolveToken(HttpServletRequest request) {
-        String bearerToken = request.getHeader("Authorization");
-        if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
-            return bearerToken.substring(7);
+    /** Authorization: Bearer ... 헤더에서 토큰만 추출 */
+    public String resolveToken(HttpServletRequest req) {
+        String h = req.getHeader("Authorization");
+        if (h == null) return null;
+        h = h.trim();
+        if (h.regionMatches(true, 0, "Bearer ", 0, 7)) {
+            return h.substring(7).trim();
         }
         return null;
+    }
+
+    /* ====== Internal ====== */
+
+    private Claims parseClaims(String token) {
+        var parser = Jwts.parserBuilder().setSigningKey(key).build();
+        var jws = parser.parseClaimsJws(token);
+        Claims c = jws.getBody();
+
+        // issuer가 설정되어 있으면 검사(선택)
+        if (issuer != null && !issuer.isBlank()) {
+            if (!Objects.equals(issuer, c.getIssuer())) {
+                throw new JwtException("Invalid issuer");
+            }
+        }
+        // 만료는 JJWT가 ExpiredJwtException으로 이미 처리
+        Date exp = c.getExpiration();
+        if (exp != null && exp.before(new Date())) {
+            throw new ExpiredJwtException(jws.getHeader(), c, "Expired");
+        }
+        return c;
+    }
+
+    private static Long claimAsLong(Claims c, String name) {
+        Object v = c.get(name);
+        if (v == null) return null;
+        if (v instanceof Number n) return n.longValue();
+        try { return Long.parseLong(String.valueOf(v)); } catch (NumberFormatException e) { return null; }
+    }
+
+    private static String claimAsString(Claims c, String name) {
+        Object v = c.get(name);
+        if (v == null) return null;
+        String s = String.valueOf(v).trim();
+        return s.isEmpty() ? null : s;
     }
 }

--- a/src/main/java/com/example/moyeorak/service/admin/AdminMainImageService.java
+++ b/src/main/java/com/example/moyeorak/service/admin/AdminMainImageService.java
@@ -27,18 +27,20 @@ public class AdminMainImageService {
 
     private final MainImageRepository mainImageRepository;
     private final AdminAuthHelper adminAuthHelper;
+
+    /** Presigner is injected (recommended to define as @Bean). */
     private final S3Presigner s3Presigner;
 
-    /** 프로퍼티가 비어 있어도 부팅되게 하고, 런타임에 검사 */
+    /** Allow startup even if property is empty, check at runtime. */
     @Value("${app.s3.bucket:}")
     private String bucketName;
 
-    /* ========================= 조회 ========================= */
+    /* ========================= Read ========================= */
     @Transactional(readOnly = true)
     public List<AdminMainImageResponse> getMainImages(HttpServletRequest request) {
         User admin = adminAuthHelper.getAdminFromRequest(request);
         if (admin.getRegion() == null || admin.getRegion().getId() == null) {
-            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "접근 권한이 없습니다.");
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "No permission for this region.");
         }
         Long regionId = admin.getRegion().getId();
 
@@ -48,17 +50,17 @@ public class AdminMainImageService {
                 .toList();
     }
 
-    /* ========================= 생성 ========================= */
+    /* ========================= Create ========================= */
     @Transactional
     public AdminMainImageResponse createMainImage(AdminMainImageCreateRequest dto, HttpServletRequest request) {
         User admin = adminAuthHelper.getAdminFromRequest(request);
         if (admin.getRegion() == null || admin.getRegion().getId() == null) {
-            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "접근 권한이 없습니다.");
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "No permission for this region.");
         }
         Long regionId = admin.getRegion().getId();
 
         if (dto.getImageUrl() == null || dto.getImageUrl().isBlank()) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "이미지 URL은 필수입니다.");
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "imageUrl is required.");
         }
 
         Integer maxOrder = mainImageRepository.findMaxDisplayOrderByRegionId(regionId);
@@ -66,7 +68,7 @@ public class AdminMainImageService {
 
         MainImage image = MainImage.builder()
                 .imageUrl(dto.getImageUrl())
-                .title("") // 필요 시 dto.getTitle() 사용
+                .title("")                 // use dto.getTitle() if needed
                 .displayOrder(nextOrder)
                 .isActive(true)
                 .region(admin.getRegion())
@@ -75,62 +77,70 @@ public class AdminMainImageService {
         return AdminMainImageResponse.from(mainImageRepository.save(image));
     }
 
-    /* ============== 일괄 수정 (표시여부/순서) ============== */
+    /* ============== Bulk Update (Status/Order) ============== */
     @Transactional
     public void updateMainImages(List<AdminMainImageUpdateRequest> requestList, HttpServletRequest request) {
         User admin = adminAuthHelper.getAdminFromRequest(request);
         if (admin.getRegion() == null || admin.getRegion().getId() == null) {
-            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "접근 권한이 없습니다.");
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "No permission for this region.");
         }
         Long regionId = admin.getRegion().getId();
 
         for (AdminMainImageUpdateRequest req : requestList) {
             MainImage image = mainImageRepository.findById(req.getId())
-                    .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "홍보물을 찾을 수 없습니다."));
+                    .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Main image not found."));
 
+            // prevent editing resources of other regions
             if (image.getRegion() == null || !image.getRegion().getId().equals(regionId)) {
-                throw new ResponseStatusException(HttpStatus.FORBIDDEN, "해당 지역 리소스에 대한 권한이 없습니다.");
+                throw new ResponseStatusException(HttpStatus.FORBIDDEN, "No permission for this region resource.");
             }
 
-            // if (req.getDisplayOrder() != null) image.changeDisplayOrder(req.getDisplayOrder());
-            if (req.getIsActive() != null) image.changeActiveStatus(req.getIsActive());
+            // If you want to enable order change, open the entity method.
+            // if (req.getDisplayOrder() != null) {
+            //     image.changeDisplayOrder(req.getDisplayOrder());
+            // }
+
+            if (req.getIsActive() != null) {
+                image.changeActiveStatus(req.getIsActive());
+            }
         }
     }
 
-    /* ========================= 삭제 ========================= */
+    /* ========================= Delete ========================= */
     @Transactional
     public void deleteById(Long id, HttpServletRequest request) {
         User admin = adminAuthHelper.getAdminFromRequest(request);
         if (admin.getRegion() == null || admin.getRegion().getId() == null) {
-            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "접근 권한이 없습니다.");
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "No permission for this region.");
         }
         Long regionId = admin.getRegion().getId();
 
         MainImage image = mainImageRepository.findById(id)
-                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "홍보물을 찾을 수 없습니다."));
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Main image not found."));
 
         if (image.getRegion() == null || !image.getRegion().getId().equals(regionId)) {
-            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "해당 지역 리소스에 대한 권한이 없습니다.");
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "No permission for this region resource.");
         }
 
         mainImageRepository.delete(image);
     }
 
-    /* ============== S3 Presigned PUT URL 생성 ============== */
+    /* ============== S3 Presigned PUT URL ============== */
     @Transactional(readOnly = true)
     public String createPresignedPutUrl(String filename, String filetype, HttpServletRequest request) {
         User admin = adminAuthHelper.getAdminFromRequest(request);
         if (admin.getRegion() == null || admin.getRegion().getId() == null) {
-            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "접근 권한이 없습니다.");
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "No permission for this region.");
+        }
+
+        if (bucketName == null || bucketName.isBlank()) {
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "S3 bucket is not configured.");
         }
         if (filename == null || filename.isBlank()) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "filename은 필수입니다.");
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "filename is required.");
         }
         if (filetype == null || filetype.isBlank()) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "filetype은 필수입니다.");
-        }
-        if (bucketName == null || bucketName.isBlank()) {
-            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "S3 버킷(app.s3.bucket) 설정이 누락되었습니다.");
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "filetype is required.");
         }
 
         String key = "main-images/" + admin.getRegion().getId() + "/" + filename;
@@ -146,6 +156,7 @@ public class AdminMainImageService {
                 .putObjectRequest(putObject)
                 .build();
 
+        // Use injected presigner (no per-call create/close).
         return s3Presigner.presignPutObject(presignReq).url().toString();
     }
 }

--- a/src/main/java/com/example/moyeorak/service/admin/AdminMainImageService.java
+++ b/src/main/java/com/example/moyeorak/service/admin/AdminMainImageService.java
@@ -5,16 +5,20 @@ import com.example.moyeorak.dto.admin.AdminMainImageResponse;
 import com.example.moyeorak.dto.admin.AdminMainImageUpdateRequest;
 import com.example.moyeorak.entity.MainImage;
 import com.example.moyeorak.entity.User;
-import com.example.moyeorak.exception.BusinessException;
-import com.example.moyeorak.exception.ErrorCode;
 import com.example.moyeorak.repository.MainImageRepository;
 import com.example.moyeorak.security.AdminAuthHelper;
-import jakarta.persistence.EntityNotFoundException;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
 
+import java.time.Duration;
 import java.util.List;
 
 @Service
@@ -23,31 +27,46 @@ public class AdminMainImageService {
 
     private final MainImageRepository mainImageRepository;
     private final AdminAuthHelper adminAuthHelper;
+    private final S3Presigner s3Presigner;
 
+    /** 프로퍼티가 비어 있어도 부팅되게 하고, 런타임에 검사 */
+    @Value("${app.s3.bucket:}")
+    private String bucketName;
 
-    // 홍보물 리스트 조회
+    /* ========================= 조회 ========================= */
     @Transactional(readOnly = true)
     public List<AdminMainImageResponse> getMainImages(HttpServletRequest request) {
         User admin = adminAuthHelper.getAdminFromRequest(request);
+        if (admin.getRegion() == null || admin.getRegion().getId() == null) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "접근 권한이 없습니다.");
+        }
         Long regionId = admin.getRegion().getId();
 
-        return mainImageRepository.findByRegionIdOrderByDisplayOrderAsc(regionId).stream()
+        return mainImageRepository.findByRegionIdOrderByDisplayOrderAsc(regionId)
+                .stream()
                 .map(AdminMainImageResponse::from)
                 .toList();
     }
 
-    // 홍보물 생성
+    /* ========================= 생성 ========================= */
     @Transactional
     public AdminMainImageResponse createMainImage(AdminMainImageCreateRequest dto, HttpServletRequest request) {
         User admin = adminAuthHelper.getAdminFromRequest(request);
+        if (admin.getRegion() == null || admin.getRegion().getId() == null) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "접근 권한이 없습니다.");
+        }
         Long regionId = admin.getRegion().getId();
+
+        if (dto.getImageUrl() == null || dto.getImageUrl().isBlank()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "이미지 URL은 필수입니다.");
+        }
 
         Integer maxOrder = mainImageRepository.findMaxDisplayOrderByRegionId(regionId);
         int nextOrder = (maxOrder != null) ? maxOrder + 1 : 1;
 
         MainImage image = MainImage.builder()
                 .imageUrl(dto.getImageUrl())
-                .title("")
+                .title("") // 필요 시 dto.getTitle() 사용
                 .displayOrder(nextOrder)
                 .isActive(true)
                 .region(admin.getRegion())
@@ -56,24 +75,77 @@ public class AdminMainImageService {
         return AdminMainImageResponse.from(mainImageRepository.save(image));
     }
 
-    // 홍보물 일괄 수정 (표시여부 + 순서)
+    /* ============== 일괄 수정 (표시여부/순서) ============== */
     @Transactional
-    public void updateMainImages(List<AdminMainImageUpdateRequest> requestList) {
+    public void updateMainImages(List<AdminMainImageUpdateRequest> requestList, HttpServletRequest request) {
+        User admin = adminAuthHelper.getAdminFromRequest(request);
+        if (admin.getRegion() == null || admin.getRegion().getId() == null) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "접근 권한이 없습니다.");
+        }
+        Long regionId = admin.getRegion().getId();
+
         for (AdminMainImageUpdateRequest req : requestList) {
             MainImage image = mainImageRepository.findById(req.getId())
-                    .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND_MAIN_IMAGE_ID));
+                    .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "홍보물을 찾을 수 없습니다."));
 
-            //image.changeDisplayOrder(req.getDisplayOrder()); 다시 처리 할 예정
-            image.changeActiveStatus(req.getIsActive());
+            if (image.getRegion() == null || !image.getRegion().getId().equals(regionId)) {
+                throw new ResponseStatusException(HttpStatus.FORBIDDEN, "해당 지역 리소스에 대한 권한이 없습니다.");
+            }
+
+            // if (req.getDisplayOrder() != null) image.changeDisplayOrder(req.getDisplayOrder());
+            if (req.getIsActive() != null) image.changeActiveStatus(req.getIsActive());
         }
     }
 
-    // 홍보물 삭제
-    public void deleteById(Long id) {
-        if (!mainImageRepository.existsById(id)) {
-            throw new BusinessException(ErrorCode.NOT_FOUND_MAIN_IMAGE_ID);
+    /* ========================= 삭제 ========================= */
+    @Transactional
+    public void deleteById(Long id, HttpServletRequest request) {
+        User admin = adminAuthHelper.getAdminFromRequest(request);
+        if (admin.getRegion() == null || admin.getRegion().getId() == null) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "접근 권한이 없습니다.");
         }
-        mainImageRepository.deleteById(id);
+        Long regionId = admin.getRegion().getId();
+
+        MainImage image = mainImageRepository.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "홍보물을 찾을 수 없습니다."));
+
+        if (image.getRegion() == null || !image.getRegion().getId().equals(regionId)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "해당 지역 리소스에 대한 권한이 없습니다.");
+        }
+
+        mainImageRepository.delete(image);
     }
 
+    /* ============== S3 Presigned PUT URL 생성 ============== */
+    @Transactional(readOnly = true)
+    public String createPresignedPutUrl(String filename, String filetype, HttpServletRequest request) {
+        User admin = adminAuthHelper.getAdminFromRequest(request);
+        if (admin.getRegion() == null || admin.getRegion().getId() == null) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "접근 권한이 없습니다.");
+        }
+        if (filename == null || filename.isBlank()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "filename은 필수입니다.");
+        }
+        if (filetype == null || filetype.isBlank()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "filetype은 필수입니다.");
+        }
+        if (bucketName == null || bucketName.isBlank()) {
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "S3 버킷(app.s3.bucket) 설정이 누락되었습니다.");
+        }
+
+        String key = "main-images/" + admin.getRegion().getId() + "/" + filename;
+
+        PutObjectRequest putObject = PutObjectRequest.builder()
+                .bucket(bucketName)
+                .key(key)
+                .contentType(filetype)
+                .build();
+
+        PutObjectPresignRequest presignReq = PutObjectPresignRequest.builder()
+                .signatureDuration(Duration.ofMinutes(5))
+                .putObjectRequest(putObject)
+                .build();
+
+        return s3Presigner.presignPutObject(presignReq).url().toString();
+    }
 }


### PR DESCRIPTION
…seStatusException; JWT token generation helpersChanges

AWS S3 Presigner

AwsClientsConfig에 S3Presigner Bean 추가

AdminMainImageService에서 Presigner 주입받아 사용하도록 수정

AdminMainImageService

비즈니스 예외(BusinessException) → ResponseStatusException 으로 교체

잘못된 ErrorCode 의존성 제거

이미지 생성/수정/삭제 시 지역 권한 검증 로직 추가

S3 Presigned PUT URL 생성 메서드(createPresignedPutUrl) 구현 완료

JWT Provider

generateToken, generateRefreshToken 유틸 추가

UserController에서 JWT 토큰 발급 정상 동작하도록 수정

Motivation

빌드 시 발생하던 cannot find symbol 및 잘못된 ErrorCode 상수 문제 해결

S3 Presigner 주입 오류 (Could not resolve placeholder 'app.s3.bucket') 대응

기존 토큰 발급 로직을 개선하여 Role Claim 기반 인증이 가능하도록 변경
