### PR TITLE
fix: remove Content-Type from S3 presigned URL to resolve CORS/403 issue

### DIFF
--- a/src/main/java/com/example/moyeorak/config/AwsClientsConfig.java
+++ b/src/main/java/com/example/moyeorak/config/AwsClientsConfig.java
@@ -16,47 +16,49 @@ import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 @Configuration
 public class AwsClientsConfig {
 
-    // 다른 설정들과 통일: cloud.aws.region.static
+    /** AWS Region (application.yml의 cloud.aws.region.static 사용, 기본값: ap-northeast-2) */
     @Value("${cloud.aws.region.static:ap-northeast-2}")
     private String region;
 
-    // 로컬(프로파일) / 운영(IAM Role) 전환 플래그
+    /** 자격 증명 공급자 선택 플래그: true → DefaultCredentialsProvider (IAM Role/Env), false → ProfileCredentialsProvider */
     @Value("${aws.use.default-credentials:true}")
     private boolean useDefaultCredentials;
 
-    // 로컬에서 사용할 Shared Credentials 프로파일명
+    /** 로컬 개발 시 사용할 AWS profile 이름 (~/.aws/credentials) */
     @Value("${aws.profile.name:sqs-user}")
     private String profileName;
 
-    /** 공용 CredentialsProvider (S3/CloudWatch/SQS에서 재사용) */
+    /** 공용 CredentialsProvider (S3/CloudWatch/SQS 등 모든 클라이언트에서 재사용) */
     @Bean
     public AwsCredentialsProvider awsCredentialsProvider() {
         if (useDefaultCredentials) {
-            log.info("[AWS Creds] DefaultCredentialsProvider (IAM Role/Env)");
+            log.info("[AWS Creds] Using DefaultCredentialsProvider (IAM Role / Env vars)");
             return DefaultCredentialsProvider.create();
         } else {
-            log.info("[AWS Creds] ProfileCredentialsProvider profile={}", profileName);
+            log.info("[AWS Creds] Using ProfileCredentialsProvider profile={}", profileName);
             return ProfileCredentialsProvider.create(profileName);
         }
     }
 
+    /** CloudWatch Metrics Client */
     @Bean
     public CloudWatchClient cloudWatchClient(AwsCredentialsProvider creds) {
         CloudWatchClient client = CloudWatchClient.builder()
                 .region(Region.of(region))
                 .credentialsProvider(creds)
                 .build();
-        log.info("[CloudWatch] region={}", region);
+        log.info("[CloudWatch] initialized region={}", region);
         return client;
     }
 
+    /** CloudWatch Logs Client */
     @Bean
     public CloudWatchLogsClient cloudWatchLogsClient(AwsCredentialsProvider creds) {
         CloudWatchLogsClient client = CloudWatchLogsClient.builder()
                 .region(Region.of(region))
                 .credentialsProvider(creds)
                 .build();
-        log.info("[CloudWatchLogs] region={}", region);
+        log.info("[CloudWatchLogs] initialized region={}", region);
         return client;
     }
 
@@ -67,7 +69,7 @@ public class AwsClientsConfig {
                 .region(Region.of(region))
                 .credentialsProvider(creds)
                 .build();
-        log.info("[S3Presigner] region={}", region);
+        log.info("[S3Presigner] initialized region={}", region);
         return presigner;
     }
 }

--- a/src/main/java/com/example/moyeorak/controller/admin/AdminMainImageController.java
+++ b/src/main/java/com/example/moyeorak/controller/admin/AdminMainImageController.java
@@ -75,10 +75,10 @@ public class AdminMainImageController {
             HttpServletRequest httpRequest
     ) {
         String filename = body.filename();
-        String contentType = body.contentType();
+        String contentType = body.contentType(); // optional
 
-        if (isBlank(filename) || isBlank(contentType)) {
-            return ResponseEntity.badRequest().body("filename과 contentType는 비어 있을 수 없습니다.");
+        if (isBlank(filename)) {
+            return ResponseEntity.badRequest().body("filename은 비어 있을 수 없습니다.");
         }
 
         String url = adminMainImageService.createPresignedPutUrl(filename, contentType, httpRequest);
@@ -90,7 +90,7 @@ public class AdminMainImageController {
     // - 기존 클라이언트가 보내는 filetype도 지원
     // - contentType이 있으면 contentType 우선
     // -------------------------------
-    @Operation(summary = "S3 업로드용 Presigned URL 발급 (호환: GET + query, contentType/filetype 지원)")
+    @Operation(summary = "S3 업로드용 Presigned URL 발급 (호환: GET + query, contentType/filetype 선택)")
     @GetMapping("/presigned-url")
     public ResponseEntity<String> getPresignedUrl(
             @RequestParam String filename,
@@ -102,9 +102,6 @@ public class AdminMainImageController {
 
         if (isBlank(filename)) {
             return ResponseEntity.badRequest().body("필수 파라미터 누락: filename");
-        }
-        if (isBlank(ct)) {
-            return ResponseEntity.badRequest().body("필수 파라미터 누락: contentType (alias: filetype)");
         }
 
         String url = adminMainImageService.createPresignedPutUrl(filename, ct, httpRequest);
@@ -120,10 +117,10 @@ public class AdminMainImageController {
 
     /**
      * POST /presigned-url 요청용 DTO
-     * contentType에는 MIME 전체값을 넣어야 합니다. 예: image/jpeg, image/png, image/webp
+     * contentType은 선택값입니다. (서명에는 사용하지 않음)
      */
     public record PresignUrlRequest(
             @NotBlank String filename,
-            @NotBlank String contentType
+            String contentType
     ) {}
 }

--- a/src/main/java/com/example/moyeorak/controller/admin/AdminMainImageController.java
+++ b/src/main/java/com/example/moyeorak/controller/admin/AdminMainImageController.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.lang.Nullable;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -121,6 +122,6 @@ public class AdminMainImageController {
      */
     public record PresignUrlRequest(
             @NotBlank String filename,
-            String contentType
+            @Nullable String contentType
     ) {}
 }

--- a/src/main/java/com/example/moyeorak/service/admin/AdminMainImageService.java
+++ b/src/main/java/com/example/moyeorak/service/admin/AdminMainImageService.java
@@ -149,7 +149,7 @@ public class AdminMainImageService {
         String safeFilename = sanitizeFilename(filename);
         String key = "main-images/" + admin.getRegion().getId() + "/" + safeFilename;
 
-        // 👇 Content-Type을 설정하지 않습니다 → SignedHeaders에서 제외됨(host만 남음)
+        // We intentionally do not set Content-Type so it is excluded from the signed headers (only 'host' remains).
         PutObjectRequest putObject = PutObjectRequest.builder()
                 .bucket(bucketName)
                 .key(key)

--- a/src/main/java/com/example/moyeorak/service/admin/AdminMainImageService.java
+++ b/src/main/java/com/example/moyeorak/service/admin/AdminMainImageService.java
@@ -36,7 +36,7 @@ public class AdminMainImageService {
     @Value("${app.s3.bucket:}")
     private String bucketName;
 
-    /** 허용할 이미지 Content-Type 화이트리스트 */
+    /** 허용할 이미지 Content-Type 화이트리스트 (선택 입력 시 검증용) */
     private static final Set<String> ALLOWED_CONTENT_TYPES = Set.of(
             "image/jpeg",
             "image/png",
@@ -127,9 +127,11 @@ public class AdminMainImageService {
         mainImageRepository.delete(image);
     }
 
-    /* ============== S3 Presigned PUT URL (권장 시그니처: contentType) ============== */
+    /* ============== S3 Presigned PUT URL (Content-Type은 서명에서 제외) ============== */
     @Transactional(readOnly = true)
-    public String createPresignedPutUrl(String filename, String contentType, HttpServletRequest request) {
+    public String createPresignedPutUrl(String filename,
+                                        String contentType, // optional: 검증/로그용, 서명에는 반영하지 않음
+                                        HttpServletRequest request) {
         User admin = adminAuthHelper.getAdminFromRequest(request);
         ensureRegionAccess(admin);
 
@@ -139,20 +141,18 @@ public class AdminMainImageService {
         if (isBlank(filename)) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "filename is required.");
         }
-        if (isBlank(contentType)) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "contentType is required.");
-        }
-        if (!ALLOWED_CONTENT_TYPES.contains(contentType)) {
+        // contentType은 선택값: 있으면 화이트리스트 검증만 수행(서명에는 반영하지 않음)
+        if (!isBlank(contentType) && !ALLOWED_CONTENT_TYPES.contains(contentType)) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Unsupported contentType: " + contentType);
         }
 
         String safeFilename = sanitizeFilename(filename);
         String key = "main-images/" + admin.getRegion().getId() + "/" + safeFilename;
 
+        // 👇 Content-Type을 설정하지 않습니다 → SignedHeaders에서 제외됨(host만 남음)
         PutObjectRequest putObject = PutObjectRequest.builder()
                 .bucket(bucketName)
                 .key(key)
-                .contentType(contentType)
                 .build();
 
         PutObjectPresignRequest presignReq = PutObjectPresignRequest.builder()


### PR DESCRIPTION
### 변경 내용
- S3 presigned URL 생성 시 `Content-Type` 헤더를 서명에서 제외하도록 수정
- `AdminMainImageService` / `AdminMainImageController` / `AwsClientsConfig` 코드 정리
- CORS/403 Forbidden 오류 해결을 위한 구조 개선

### 배경
- 기존에는 presigned URL 생성 시 `Content-Type`이 SignedHeaders에 포함됨
- 브라우저 preflight OPTIONS 요청에서 서명 불일치가 발생 → 403 Forbidden + CORS 에러

### 기대 효과
- 프론트엔드에서 `axios.put(uploadUrl, file)` 요청 시 더 이상 CORS/403 발생하지 않음
- 브라우저가 자동으로 붙이는 Content-Type 헤더와 presigned URL 서명이 충돌하지 않음
