### PR TITLE
fix(security): bypass OPTIONS in JwtAuthFilter and allow 5m JWT clock…

### DIFF
--- a/src/main/java/com/example/moyeorak/jwt/JwtAuthFilter.java
+++ b/src/main/java/com/example/moyeorak/jwt/JwtAuthFilter.java
@@ -39,7 +39,8 @@ public class JwtAuthFilter extends OncePerRequestFilter {
             FilterChain filterChain
     ) throws ServletException, IOException {
 
-        // ❶ Preflight(OPTIONS)는 즉시 통과
+        // ❶ Immediately allow Preflight (OPTIONS) requests.
+        //    (프리플라이트 OPTIONS 요청은 필터에서 즉시 통과시킵니다)
         if ("OPTIONS".equalsIgnoreCase(request.getMethod())) {
             filterChain.doFilter(request, response);
             return;
@@ -52,7 +53,7 @@ public class JwtAuthFilter extends OncePerRequestFilter {
             if (token != null && jwtProvider.validateToken(token)) {
                 String email = jwtProvider.getEmail(token);
                 if (email == null) {
-                    // sub 사용 케이스
+                    // Fallback: use subject if email claim is missing
                     email = jwtProvider.getSubject(token);
                 }
 
@@ -69,10 +70,10 @@ public class JwtAuthFilter extends OncePerRequestFilter {
                     userId = UNKNOWN_USER_ID;
                 }
 
-                // Optional: user 로드(없으면 null)
+                // Optional: load user entity to enrich principal (nullable)
                 var user = (email != null) ? userRepository.findByEmail(email).orElse(null) : null;
 
-                var principal = (user != null) ? user : email; // fallback: email 문자열
+                var principal = (user != null) ? user : email; // fallback to email string
                 var auth = new UsernamePasswordAuthenticationToken(principal, null, authorities);
                 auth.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
                 SecurityContextHolder.getContext().setAuthentication(auth);
@@ -82,11 +83,14 @@ public class JwtAuthFilter extends OncePerRequestFilter {
                             userId, email, authorities);
                 }
             } else {
-                if (token != null) {
-                    log.warn("JWT validation failed or token is null/invalid");
+                // Validation failed OR token was not provided/resolved
+                if (token == null) {
+                    log.warn("No Bearer token provided or non-Bearer Authorization header.");
+                } else {
+                    log.warn("JWT validation failed for provided token.");
                 }
                 if (devBypass && SecurityContextHolder.getContext().getAuthentication() == null) {
-                    bypassAsTempUser(request, "Validation failed (dev bypass)");
+                    bypassAsTempUser(request, "Validation failed or no token (dev bypass)");
                 }
             }
         } catch (ExpiredJwtException e) {
@@ -103,7 +107,7 @@ public class JwtAuthFilter extends OncePerRequestFilter {
             }
         }
 
-        // 무토큰/비정상 포맷 + devBypass인 경우
+        // No token / non-Bearer + devBypass enabled → authenticate as temp user
         if (token == null && devBypass && SecurityContextHolder.getContext().getAuthentication() == null) {
             bypassAsTempUser(request, "No header/non-Bearer (dev bypass)");
         }

--- a/src/main/java/com/example/moyeorak/jwt/JwtAuthFilter.java
+++ b/src/main/java/com/example/moyeorak/jwt/JwtAuthFilter.java
@@ -39,6 +39,12 @@ public class JwtAuthFilter extends OncePerRequestFilter {
             FilterChain filterChain
     ) throws ServletException, IOException {
 
+        // ❶ Preflight(OPTIONS)는 즉시 통과
+        if ("OPTIONS".equalsIgnoreCase(request.getMethod())) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
         String token = null;
         try {
             token = jwtProvider.resolveToken(request);
@@ -46,7 +52,7 @@ public class JwtAuthFilter extends OncePerRequestFilter {
             if (token != null && jwtProvider.validateToken(token)) {
                 String email = jwtProvider.getEmail(token);
                 if (email == null) {
-                    // Handle case where sub is used as email
+                    // sub 사용 케이스
                     email = jwtProvider.getSubject(token);
                 }
 
@@ -60,38 +66,45 @@ public class JwtAuthFilter extends OncePerRequestFilter {
 
                 Long userId = jwtProvider.getUserId(token);
                 if (userId == null) {
-                    userId = UNKNOWN_USER_ID; // explicit placeholder
+                    userId = UNKNOWN_USER_ID;
                 }
 
-                // Optional: load user to enrich context (safe to be null)
+                // Optional: user 로드(없으면 null)
                 var user = (email != null) ? userRepository.findByEmail(email).orElse(null) : null;
 
-                var principal = (user != null) ? user : email; // fallback to email string
+                var principal = (user != null) ? user : email; // fallback: email 문자열
                 var auth = new UsernamePasswordAuthenticationToken(principal, null, authorities);
                 auth.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
                 SecurityContextHolder.getContext().setAuthentication(auth);
 
-                log.debug("✅ JWT authentication successful - userId: {}, email: {}, roles: {}",
-                        userId, email, authorities);
+                if (log.isDebugEnabled()) {
+                    log.debug("✅ JWT authentication successful - userId: {}, email: {}, roles: {}",
+                            userId, email, authorities);
+                }
             } else {
-                if (devBypass) {
+                if (token != null) {
+                    log.warn("JWT validation failed or token is null/invalid");
+                }
+                if (devBypass && SecurityContextHolder.getContext().getAuthentication() == null) {
                     bypassAsTempUser(request, "Validation failed (dev bypass)");
                 }
             }
         } catch (ExpiredJwtException e) {
-            log.debug("JWT expired: {}", e.getMessage());
+            log.warn("JWT expired: sub={}, exp={}",
+                    e.getClaims() != null ? e.getClaims().getSubject() : null,
+                    e.getClaims() != null ? e.getClaims().getExpiration() : null);
             if (devBypass) {
                 bypassAsTempUser(request, "Expired (dev bypass)");
             }
         } catch (Exception e) {
-            log.debug("JWT parse/validation error: {}", e.getMessage());
+            log.warn("JWT validation error: {}", e.getMessage());
             if (devBypass) {
                 bypassAsTempUser(request, "Signature/format error (dev bypass)");
             }
         }
 
+        // 무토큰/비정상 포맷 + devBypass인 경우
         if (token == null && devBypass && SecurityContextHolder.getContext().getAuthentication() == null) {
-            // No header/non-Bearer etc.
             bypassAsTempUser(request, "No header/non-Bearer (dev bypass)");
         }
 

--- a/src/main/java/com/example/moyeorak/jwt/JwtProvider.java
+++ b/src/main/java/com/example/moyeorak/jwt/JwtProvider.java
@@ -20,29 +20,29 @@ import java.util.Objects;
 public class JwtProvider {
 
     @Value("${jwt.secret}")
-    private String secret; // HS256용 비밀키 (Base64 권장, 32바이트 이상)
+    private String secret; // HS256 secret (Base64 recommended, >=32 bytes)
 
     @Value("${jwt.issuer:}")
-    private String issuer; // 선택값
+    private String issuer; // optional
 
-    @Value("${jwt.access-token.ttl-seconds:1800}")   // 기본 30분
+    @Value("${jwt.access-token.ttl-seconds:1800}")   // default 30m
     private long accessTokenTtlSeconds;
 
-    @Value("${jwt.refresh-token.ttl-seconds:1209600}") // 기본 14일
+    @Value("${jwt.refresh-token.ttl-seconds:1209600}") // default 14d
     private long refreshTokenTtlSeconds;
 
     private Key key;
 
     @PostConstruct
     void init() {
-        // Base64로 우선 시도, 실패하면 raw bytes 사용
+        // Try Base64 first; if fails, fall back to raw bytes
         try {
             byte[] decoded = Decoders.BASE64.decode(secret);
             this.key = Keys.hmacShaKeyFor(decoded);
         } catch (Exception e) {
             byte[] raw = secret.getBytes(StandardCharsets.UTF_8);
             if (raw.length < 32) {
-                log.warn("jwt.secret 길이가 짧습니다(>=32 bytes 권장). 현재: {} bytes", raw.length);
+                log.warn("jwt.secret is short (>=32 bytes recommended). current: {} bytes", raw.length);
             }
             this.key = Keys.hmacShaKeyFor(raw);
         }
@@ -50,14 +50,14 @@ public class JwtProvider {
 
     /* ====== Token Generation ====== */
 
-    /** Access Token 생성 (subject=email, roles=role 문자열) */
+    /** Access Token (subject=email, roles=role string) */
     public String generateToken(String email, String role) {
         long now = System.currentTimeMillis();
         long expMillis = now + (accessTokenTtlSeconds * 1000L);
 
         var builder = Jwts.builder()
                 .setSubject(email)
-                .claim("roles", role)              // (예) "ADMIN"
+                .claim("roles", role)              // e.g., "ADMIN"
                 .setIssuedAt(new Date(now))
                 .setExpiration(new Date(expMillis));
 
@@ -68,7 +68,7 @@ public class JwtProvider {
         return builder.signWith(key, SignatureAlgorithm.HS256).compact();
     }
 
-    /** Refresh Token 생성 (subject=email, 권한 등 부가클레임 없이 긴 만료) */
+    /** Refresh Token (subject=email, no extra claims, long expiry) */
     public String generateRefreshToken(String email) {
         long now = System.currentTimeMillis();
         long expMillis = now + (refreshTokenTtlSeconds * 1000L);
@@ -87,10 +87,10 @@ public class JwtProvider {
 
     /* ====== Public API ====== */
 
-    /** 토큰 유효성 검증(서명/만료 등) */
+    /** Validate token (signature/exp/etc.) */
     public boolean validateToken(String token) {
         try {
-            parseClaims(token); // 파싱되면 유효
+            parseClaims(token); // parsing succeeds => valid
             return true;
         } catch (ExpiredJwtException e) {
             log.debug("JWT expired: {}", e.getMessage());
@@ -101,7 +101,7 @@ public class JwtProvider {
         }
     }
 
-    /** userId 클레임(숫자) 또는 subject가 숫자면 반환 */
+    /** userId claim as Long (supports id/userId/uid or numeric sub) */
     public Long getUserId(String token) {
         try {
             Claims c = parseClaims(token);
@@ -114,7 +114,6 @@ public class JwtProvider {
             id = claimAsLong(c, "uid");
             if (id != null) return id;
 
-            // sub가 숫자면 허용
             String sub = c.getSubject();
             if (sub != null) {
                 try { return Long.parseLong(sub); } catch (NumberFormatException ignored) {}
@@ -125,7 +124,7 @@ public class JwtProvider {
         }
     }
 
-    /** email 클레임 또는 subject(이메일 형태면) */
+    /** email claim or subject (if looks like email) */
     public String getEmail(String token) {
         try {
             Claims c = parseClaims(token);
@@ -141,7 +140,7 @@ public class JwtProvider {
         }
     }
 
-    /** subject 그대로 반환 */
+    /** Return subject as-is */
     public String getSubject(String token) {
         try {
             return parseClaims(token).getSubject();
@@ -150,21 +149,20 @@ public class JwtProvider {
         }
     }
 
-    /** 단일 role 또는 roles 첫 번째 값(문자열/리스트/배열 모두 지원) */
+    /** Single role or first of roles (supports string/list/array) */
     public String getRole(String token) {
         try {
             Claims c = parseClaims(token);
 
-            // 1) role(단수)
+            // 1) role (singular)
             String role = claimAsString(c, "role");
             if (role != null) return role;
 
-            // 2) roles(복수)
+            // 2) roles (plural)
             Object roles = c.get("roles");
             if (roles == null) return null;
 
             if (roles instanceof String s) {
-                // "ADMIN" 또는 "ADMIN,USER"
                 String first = s.split(",")[0].trim();
                 return first.isEmpty() ? null : first;
             }
@@ -183,7 +181,7 @@ public class JwtProvider {
         }
     }
 
-    /** (선택) regionId 클레임 */
+    /** (optional) regionId claim */
     public Long getRegionId(String token) {
         try {
             Claims c = parseClaims(token);
@@ -193,7 +191,7 @@ public class JwtProvider {
         }
     }
 
-    /** Authorization: Bearer ... 헤더에서 토큰만 추출 */
+    /** Extract Bearer token from Authorization header */
     public String resolveToken(HttpServletRequest req) {
         String h = req.getHeader("Authorization");
         if (h == null) return null;
@@ -207,7 +205,8 @@ public class JwtProvider {
     /* ====== Internal ====== */
 
     private Claims parseClaims(String token) {
-        // ❷ Clock skew 허용(±300초)
+        // ❷ Allow clock skew (±300s) for robust exp/nbf validation
+        //    (서버/클라이언트 시간 오차 허용을 위해 ±300초 허용)
         JwtParser parser = Jwts.parserBuilder()
                 .setSigningKey(key)
                 .setAllowedClockSkewSeconds(300)
@@ -216,13 +215,16 @@ public class JwtProvider {
         Jws<Claims> jws = parser.parseClaimsJws(token);
         Claims c = jws.getBody();
 
-        // issuer가 설정되어 있으면 검사(선택)
+        // If issuer is configured, enforce exact match (optional)
+        // (issuer가 설정되어 있으면 정확히 일치하는지 검사)
         if (issuer != null && !issuer.isBlank()) {
             if (!Objects.equals(issuer, c.getIssuer())) {
                 throw new JwtException("Invalid issuer");
             }
         }
-        // 만료(exp) 체크는 JJWT가 이미 처리하므로 수동 재검사 불필요
+
+        // Expiration is already validated by JJWT; no manual re-check necessary.
+        // (만료(exp) 검증은 JJWT가 이미 수행하므로 수동 재검사가 필요 없습니다)
         return c;
     }
 

--- a/src/main/java/com/example/moyeorak/jwt/JwtProvider.java
+++ b/src/main/java/com/example/moyeorak/jwt/JwtProvider.java
@@ -1,10 +1,6 @@
 package com.example.moyeorak.jwt;
 
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.ExpiredJwtException;
-import io.jsonwebtoken.JwtException;
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.*;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
@@ -32,7 +28,7 @@ public class JwtProvider {
     @Value("${jwt.access-token.ttl-seconds:1800}")   // 기본 30분
     private long accessTokenTtlSeconds;
 
-    @Value("${jwt.refresh-token.ttl-seconds:1209600}") // 기본 14일 = 60*60*24*14
+    @Value("${jwt.refresh-token.ttl-seconds:1209600}") // 기본 14일
     private long refreshTokenTtlSeconds;
 
     private Key key;
@@ -61,7 +57,7 @@ public class JwtProvider {
 
         var builder = Jwts.builder()
                 .setSubject(email)
-                .claim("roles", role)              // 프론트/기존 토큰과 호환(roles: "ADMIN")
+                .claim("roles", role)              // (예) "ADMIN"
                 .setIssuedAt(new Date(now))
                 .setExpiration(new Date(expMillis));
 
@@ -69,7 +65,6 @@ public class JwtProvider {
             builder.setIssuer(issuer);
         }
 
-        // HS256 서명
         return builder.signWith(key, SignatureAlgorithm.HS256).compact();
     }
 
@@ -119,7 +114,7 @@ public class JwtProvider {
             id = claimAsLong(c, "uid");
             if (id != null) return id;
 
-            // sub가 숫자면 그것도 허용
+            // sub가 숫자면 허용
             String sub = c.getSubject();
             if (sub != null) {
                 try { return Long.parseLong(sub); } catch (NumberFormatException ignored) {}
@@ -188,7 +183,7 @@ public class JwtProvider {
         }
     }
 
-    /** (선택) regionId 클레임을 쓰고 싶다면 사용 */
+    /** (선택) regionId 클레임 */
     public Long getRegionId(String token) {
         try {
             Claims c = parseClaims(token);
@@ -212,8 +207,13 @@ public class JwtProvider {
     /* ====== Internal ====== */
 
     private Claims parseClaims(String token) {
-        var parser = Jwts.parserBuilder().setSigningKey(key).build();
-        var jws = parser.parseClaimsJws(token);
+        // ❷ Clock skew 허용(±300초)
+        JwtParser parser = Jwts.parserBuilder()
+                .setSigningKey(key)
+                .setAllowedClockSkewSeconds(300)
+                .build();
+
+        Jws<Claims> jws = parser.parseClaimsJws(token);
         Claims c = jws.getBody();
 
         // issuer가 설정되어 있으면 검사(선택)
@@ -222,11 +222,7 @@ public class JwtProvider {
                 throw new JwtException("Invalid issuer");
             }
         }
-        // 만료는 JJWT가 ExpiredJwtException으로 이미 처리
-        Date exp = c.getExpiration();
-        if (exp != null && exp.before(new Date())) {
-            throw new ExpiredJwtException(jws.getHeader(), c, "Expired");
-        }
+        // 만료(exp) 체크는 JJWT가 이미 처리하므로 수동 재검사 불필요
         return c;
     }
 


### PR DESCRIPTION
## Why
관리자화면 `POST /api/cloudwatch/logs/query` 호출 시 401이 발생했습니다. 
원인 후보는 (1) CORS 프리플라이트(OPTIONS) 차단, (2) JWT 만료/시계오차로 인한 검증 실패였습니다.

## What’s changed
- **JwtAuthFilter**
  - **OPTIONS 프리플라이트 완전 패스**: Security에서 permitAll이더라도 필터에서 확실히 우회
  - **실패 로깅 강화**: 만료/파싱/서명오류 등 실패 사유를 WARN 레벨로 로깅
  - dev bypass 로직은 기존 동작 유지 (프로퍼티 `security.jwt.dev-bypass`로 제어)

- **JwtProvider**
  - **Clock skew 허용 (±300초)**: `setAllowedClockSkewSeconds(300)` 적용으로 서버/클라이언트 시간 오차 허용
  - JJWT가 이미 처리하는 만료(exp) 재검사 로직 제거(중복 체크 제거)

> 참고: `SecurityConfig`는 변경 없음. `/api/cloudwatch/**`는 `authenticated()`만 요구.

## Impact
- **프리플라이트 401 제거** → 브라우저에서 실제 POST까지 도달
- **토큰 만료/오차로 인한 불필요한 401 감소**
- 런타임 동작 변경은 필터/파서 범위로 한정. 다른 엔드포인트 영향은 제한적
